### PR TITLE
feat(web): PostHog analytics and list card A/B for midpoint user testing

### DIFF
--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,25 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-or-publishable-key
+
+# Optional: PostHog (product analytics). https://posthog.com/docs/libraries/next-js
+# Option A — inlined at build (good for local): use NEXT_PUBLIC_*.
+NEXT_PUBLIC_POSTHOG_KEY=
+NEXT_PUBLIC_POSTHOG_HOST=
+
+# Option B — Vercel Preview friendly (read at runtime on server; no rebuild when only this changes):
+# Same value as the PostHog "Project token". Server exposes it once to the browser via GET /api/posthog-config.
+POSTHOG_PROJECT_API_KEY=
+POSTHOG_API_HOST=
+
+# Optional: RFP list card A/B for midpoint testing — `headline_first` (default) vs `score_first`.
+# Set different values on two Vercel preview deployments to split testers without two codebases.
+NEXT_PUBLIC_LIST_CARD_LAYOUT=headline_first
+
+# Server-only: writes `rfp_chunks`, past-project `embedding`, and `rfp_summaries` (RLS blocks anon/authenticated inserts).
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Server-only: profile-suggest + RAG embeddings (text-embedding-3-small; never expose as NEXT_PUBLIC_*).
+OPENAI_API_KEY=
+
+# Server-only: Groq chat for POST /api/rag-test and POST /api/rag-summary (never expose as NEXT_PUBLIC_*).
+GROQ_API_KEY=

--- a/web/README.md
+++ b/web/README.md
@@ -21,3 +21,11 @@ npm run start   # after build
 ## Data
 
 The dashboard loads from **Supabase** after email + password auth: `rfps` (active + relevant), `scores`, `saved_rfps`, `contractors`, and `contractor_past_projects`. Set `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` in `.env.local` (see `.env.example`). Optional mock fixtures remain in `lib/mockData.ts` for local experiments only.
+
+## Analytics and midpoint A/B
+
+- **PostHog (two ways):**
+  - **Local / build-inlined:** `NEXT_PUBLIC_POSTHOG_KEY` (+ optional `NEXT_PUBLIC_POSTHOG_HOST` for EU).
+  - **Vercel Preview (runtime):** set **`POSTHOG_PROJECT_API_KEY`** to the same PostHog project token (server-only name). The app calls **`GET /api/posthog-config`** on load and initializes the browser SDK so Preview env changes apply without relying on build-time inlining. You can still set `NEXT_PUBLIC_POSTHOG_KEY` instead if you redeploy after every key change.
+- **Vercel:** If analytics is missing on preview, add **`POSTHOG_PROJECT_API_KEY`** for **Preview**, redeploy, then open DevTools → Network and confirm `/api/posthog-config` returns `"apiKey":"phc_..."` (not `null`).
+- **List card layout:** `NEXT_PUBLIC_LIST_CARD_LAYOUT` is `headline_first` (default) or `score_first`. Use two Vercel preview environments with different values so testers see variant A vs B without maintaining two branches.

--- a/web/app/api/posthog-config/route.ts
+++ b/web/app/api/posthog-config/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Returns PostHog project settings for browser init.
+ * Prefer POSTHOG_PROJECT_API_KEY on Vercel so the token is read at **request runtime**
+ * (Preview env) instead of only at Next.js **build** time (NEXT_PUBLIC_*).
+ */
+export async function GET() {
+  const apiKey =
+    process.env.POSTHOG_PROJECT_API_KEY ??
+    process.env.POSTHOG_KEY ??
+    process.env.NEXT_PUBLIC_POSTHOG_KEY ??
+    null;
+  const apiHost =
+    process.env.POSTHOG_API_HOST ??
+    process.env.NEXT_PUBLIC_POSTHOG_HOST ??
+    null;
+
+  return NextResponse.json(
+    { apiKey, apiHost },
+    {
+      headers: {
+        "Cache-Control": "no-store, max-age=0",
+      },
+    },
+  );
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { captureEvent } from "@/lib/analytics";
 
 type Mode = "signin" | "signup";
 
@@ -53,8 +54,13 @@ export default function LoginPage() {
           setEmail(trimmedEmail);
           setError(true);
           setMessage(formatAuthError(signErr));
+          captureEvent("auth_sign_in_fail", {
+            code: signErr.code ?? "unknown",
+            message: signErr.message,
+          });
           return;
         }
+        captureEvent("auth_sign_in_success", { mode: "signin" });
         router.push("/");
         router.refresh();
         return;
@@ -67,6 +73,10 @@ export default function LoginPage() {
       if (signUpErr) {
         setError(true);
         setMessage(formatAuthError(signUpErr));
+        captureEvent("auth_sign_up_fail", {
+          code: signUpErr.code ?? "unknown",
+          message: signUpErr.message,
+        });
         return;
       }
       if (data.user && !data.session) {
@@ -74,10 +84,14 @@ export default function LoginPage() {
         setMessage(
           "Account created. Check your email to confirm your address, then sign in.",
         );
+        captureEvent("auth_sign_up_pending_confirm", {
+          user_id: data.user.id,
+        });
         setMode("signin");
         setPassword("");
         return;
       }
+      captureEvent("auth_sign_up_success", { mode: "signup" });
       router.push("/");
       router.refresh();
     } catch (err) {
@@ -85,6 +99,10 @@ export default function LoginPage() {
       setMessage(
         err instanceof Error ? err.message : "Something went wrong.",
       );
+      captureEvent("auth_submit_exception", {
+        mode,
+        message: err instanceof Error ? err.message : "unknown",
+      });
     } finally {
       setBusy(false);
     }

--- a/web/app/providers.tsx
+++ b/web/app/providers.tsx
@@ -1,12 +1,17 @@
 "use client";
 
+import { PostHogProvider } from "@/components/PostHogProvider";
 import { DashboardProvider } from "@/context/DashboardContext";
 import type { ReactNode } from "react";
 
 export function Providers({ children }: { children: ReactNode }) {
   return (
-    <DashboardProvider>
-      <div className="flex min-h-dvh w-full min-w-0 flex-1 flex-col">{children}</div>
-    </DashboardProvider>
+    <PostHogProvider>
+      <DashboardProvider>
+        <div className="flex min-h-dvh w-full min-w-0 flex-1 flex-col">
+          {children}
+        </div>
+      </DashboardProvider>
+    </PostHogProvider>
   );
 }

--- a/web/components/DetailPanel.tsx
+++ b/web/components/DetailPanel.tsx
@@ -4,6 +4,7 @@ import dynamic from "next/dynamic";
 import { useEffect, useState, type Dispatch, type SetStateAction } from "react";
 import ReactMarkdown from "react-markdown";
 import { useDashboard } from "@/context/DashboardContext";
+import { captureEvent } from "@/lib/analytics";
 import { isPdfUrl } from "@/lib/pdf";
 import type { Rfp } from "@/lib/types";
 import { SourceDocumentEmbed } from "./SourceDocumentEmbed";
@@ -141,9 +142,11 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
   };
 
   const handleSummary = async () => {
+    captureEvent("rag_summary_requested", { rfp_id: rfp.id });
     const found = await tryLoadCachedSummary(rfp.id);
     if (found) {
       showToast("Loaded cached summary from the database.");
+      captureEvent("rag_summary_cached_hit", { rfp_id: rfp.id });
       return;
     }
     showToast(
@@ -170,7 +173,10 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
           <button
             key={id}
             type="button"
-            onClick={() => setTab(id)}
+            onClick={() => {
+              setTab(id);
+              captureEvent("detail_tab_changed", { tab: id, rfp_id: rfp.id });
+            }}
             data-walkthrough-tab={id}
             className={`pdf-viewer-button relative pb-2.5 text-sm font-semibold transition ${
               tab === id

--- a/web/components/PostHogProvider.tsx
+++ b/web/components/PostHogProvider.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import {
+  initPosthog,
+  initPosthogWithConfig,
+} from "@/lib/analytics";
+import posthog from "posthog-js";
+import { PostHogProvider as PHProvider } from "posthog-js/react";
+import { useEffect, type ReactNode } from "react";
+
+export function PostHogProvider({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+      initPosthog();
+      return;
+    }
+
+    void (async () => {
+      try {
+        const res = await fetch("/api/posthog-config", { cache: "no-store" });
+        const data = (await res.json()) as {
+          apiKey: string | null;
+          apiHost: string | null;
+        };
+        if (data.apiKey) {
+          initPosthogWithConfig(data.apiKey, data.apiHost);
+        } else {
+          console.warn(
+            "[GovBid/PostHog] No project key in this deployment. Set NEXT_PUBLIC_POSTHOG_KEY (build-time) or POSTHOG_PROJECT_API_KEY (runtime, server-only) for Preview in Vercel, then redeploy.",
+          );
+        }
+      } catch (e) {
+        console.warn("[GovBid/PostHog] Failed to load /api/posthog-config", e);
+      }
+    })();
+  }, []);
+
+  return <PHProvider client={posthog}>{children}</PHProvider>;
+}

--- a/web/components/RfpCard.tsx
+++ b/web/components/RfpCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ListCardLayout } from "@/lib/analytics";
 import type { Rfp } from "@/lib/types";
 import { ScoreRing } from "./ScoreRing";
 
@@ -45,6 +46,7 @@ type Props = {
   rfp: Rfp;
   active: boolean;
   onSelect: () => void;
+  layout: ListCardLayout;
 };
 
 function dueParts(iso: string) {
@@ -73,7 +75,11 @@ function ClockIcon() {
   );
 }
 
-export function RfpCard({ rfp, active, onSelect }: Props) {
+function HeadlineFirstCard({
+  rfp,
+  active,
+  onSelect,
+}: Omit<Props, "layout">) {
   const { day, month } = dueParts(rfp.dueDate);
   const subtitle = rfp.tags[0] ?? rfp.agency;
 
@@ -96,8 +102,10 @@ export function RfpCard({ rfp, active, onSelect }: Props) {
         <p className="line-clamp-2 text-sm font-semibold leading-snug text-govbid-text md:text-base">
           {rfp.title}
         </p>
-        <p className="mt-1 line-clamp-1 text-xs text-govbid-text-muted">{subtitle}</p>
-        {/* TAGS: show all tags as colored bubbles */}
+        <p className="mt-1 line-clamp-1 text-xs font-medium text-govbid-text-muted">{subtitle}</p>
+        {rfp.tags[0] ? (
+          <p className="mt-0.5 line-clamp-1 text-[11px] text-govbid-text-muted">{rfp.agency}</p>
+        ) : null}
         <div className="mt-2 flex flex-wrap gap-1">
           {rfp.tags?.map((tag) => (
             <TagBubble key={tag} tag={tag} />
@@ -115,9 +123,61 @@ export function RfpCard({ rfp, active, onSelect }: Props) {
         </div>
       </div>
 
-      <div className="flex shrink-0 flex-col items-end justify-start gap-2">
-        <ScoreRing score={rfp.score} size={44} stroke={3} />
+      <div className="flex shrink-0 flex-col items-end justify-start gap-1">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-govbid-text-muted">
+          Match
+        </span>
+        <ScoreRing score={rfp.score} size={36} stroke={2.5} />
       </div>
     </button>
   );
+}
+
+function ScoreFirstCard({ rfp, active, onSelect }: Omit<Props, "layout">) {
+  const { day, month } = dueParts(rfp.dueDate);
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`flex w-full gap-3 rounded-xl border bg-govbid-surface p-4 text-left shadow-[var(--govbid-shadow)] transition md:gap-4 md:p-5 ${
+        active
+          ? "border-govbid-primary/45 bg-govbid-primary-soft/60 shadow-[0_1px_3px_rgb(79_70_229/0.12)]"
+          : "border-govbid-border hover:border-govbid-border-strong"
+      }`}
+    >
+      <div className="flex shrink-0 flex-col items-center gap-1">
+        <span className="text-[10px] font-bold uppercase tracking-wide text-govbid-primary">
+          Fit
+        </span>
+        <ScoreRing score={rfp.score} size={56} stroke={4} />
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <p className="line-clamp-2 text-sm font-semibold leading-snug text-govbid-text md:text-base">
+          {rfp.title}
+        </p>
+        <p className="mt-1 line-clamp-1 text-xs font-medium text-govbid-text">{rfp.agency}</p>
+        <p className="mt-1 text-xs font-semibold text-govbid-primary">{rfp.contract}</p>
+        <div className="mt-2 flex flex-wrap gap-1">
+          {rfp.tags.slice(0, 3).map((t) => (
+            <TagBubble key={t} tag={t} />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex shrink-0 flex-col items-center justify-center border-l border-govbid-border/80 pl-3 text-center md:pl-4">
+        <span className="text-xl font-bold leading-none text-govbid-text md:text-2xl">{day}</span>
+        <span className="mt-0.5 text-[10px] font-medium text-govbid-text-muted">{month}</span>
+        <span className="mt-2 hidden text-[10px] text-govbid-text-muted sm:inline">Due {rfp.dueDate}</span>
+      </div>
+    </button>
+  );
+}
+
+export function RfpCard({ rfp, active, onSelect, layout }: Props) {
+  if (layout === "score_first") {
+    return <ScoreFirstCard rfp={rfp} active={active} onSelect={onSelect} />;
+  }
+  return <HeadlineFirstCard rfp={rfp} active={active} onSelect={onSelect} />;
 }

--- a/web/components/RfpFeed.tsx
+++ b/web/components/RfpFeed.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getListCardLayout } from "@/lib/analytics";
 import { useDashboard } from "@/context/DashboardContext";
 import { RfpCard } from "./RfpCard";
 
@@ -24,6 +25,7 @@ function filtersActive(
 }
 
 export function RfpFeed() {
+  const listLayout = getListCardLayout();
   const {
     feedRfps,
     selectedRfpId,
@@ -52,6 +54,7 @@ export function RfpFeed() {
         <RfpCard
           key={rfp.id}
           rfp={rfp}
+          layout={listLayout}
           active={selectedRfpId === rfp.id}
           onSelect={() => selectRfp(rfp.id)}
         />

--- a/web/components/Walkthrough/Walkthrough.tsx
+++ b/web/components/Walkthrough/Walkthrough.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { WalkthroughOverlay } from "./WalkthroughOverlay";
 import { WalkthroughTooltip } from "./WalkthroughTooltip";
 import { useDashboard } from "@/context/DashboardContext";
+import { captureEvent } from "@/lib/analytics";
 
 export type WalkthroughStep =
   | "intro"
@@ -186,6 +187,14 @@ export function Walkthrough() {
 
   const [targetElement, setTargetElement] = useState<HTMLElement | null>(null);
   const [showCompletion, setShowCompletion] = useState(false);
+  const wasWalkthroughActive = useRef(false);
+
+  useEffect(() => {
+    if (walkthroughActive && !wasWalkthroughActive.current) {
+      captureEvent("walkthrough_started", { step_index: 0 });
+    }
+    wasWalkthroughActive.current = walkthroughActive;
+  }, [walkthroughActive]);
 
   // Update target element and handle step-specific logic
   useEffect(() => {
@@ -260,7 +269,7 @@ export function Walkthrough() {
     if (walkthroughStep < STEP_ORDER.length - 1) {
       setWalkthroughStep(walkthroughStep + 1);
     } else if (showCompletion) {
-      handleClose();
+      handleCompletionClick();
     }
   };
 
@@ -270,14 +279,23 @@ export function Walkthrough() {
     }
   };
 
-  const handleClose = () => {
+  const endWalkthroughUi = () => {
     setWalkthroughActive(false);
     setShowCompletion(false);
     setProfileOpen(false);
   };
 
+  const handleClose = () => {
+    captureEvent("walkthrough_dismissed", {
+      step_index: walkthroughStep,
+      show_completion: showCompletion,
+    });
+    endWalkthroughUi();
+  };
+
   const handleCompletionClick = () => {
-    handleClose();
+    captureEvent("walkthrough_completed", { step_index: walkthroughStep });
+    endWalkthroughUi();
   };
 
   if (!walkthroughActive) return null;

--- a/web/context/DashboardContext.tsx
+++ b/web/context/DashboardContext.tsx
@@ -21,6 +21,11 @@ import {
   mapRfpRow,
   profileToContractorUpdate,
 } from "@/lib/mappers";
+import {
+  captureEvent,
+  identifySessionUser,
+  resetPosthog,
+} from "@/lib/analytics";
 
 type RfpFilter = {
   tag?: string;
@@ -92,7 +97,12 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [walkthroughStep, setWalkthroughStep] = useState(0);
   const [rfpFilter, setRfpFilter] = useState<RfpFilter>({});
   const [toast, setToast] = useState<string | null>(null);
-  const [activeNav, setActiveNav] = useState<ActiveNav>("dashboard");
+  const [activeNav, setActiveNavState] = useState<ActiveNav>("dashboard");
+
+  const setActiveNav = useCallback((nav: ActiveNav) => {
+    captureEvent("main_nav_changed", { nav });
+    setActiveNavState(nav);
+  }, []);
 
   const showToast = useCallback((message: string) => {
     setToast(message);
@@ -178,6 +188,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           rfpRows?.map((row) => mapRfpRow(row, cid, scoreRows ?? undefined)) ??
           [];
         setLoadedRfps(mapped);
+        identifySessionUser(userId, { contractor_id: cid });
       } catch (e) {
         const msg = e instanceof Error ? e.message : "Unexpected error";
         showToast(msg);
@@ -307,6 +318,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   }, [loadedRfps, selectedRfpId]);
 
   const selectRfp = useCallback((id: string | null) => {
+    if (id) {
+      captureEvent("rfp_selected", { rfp_id: id });
+    }
     setSelectedRfpId(id);
   }, []);
 
@@ -334,6 +348,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           return;
         }
         setSavedRfpIds((prev) => prev.filter((x) => x !== id));
+        captureEvent("rfp_save_toggled", { rfp_id: id, now_saved: false });
       } else {
         const { error } = await supabase.from("saved_rfps").insert({
           contractor_id: contractorId,
@@ -344,6 +359,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           return;
         }
         setSavedRfpIds((prev) => [...prev, id]);
+        captureEvent("rfp_save_toggled", { rfp_id: id, now_saved: true });
       }
     },
     [contractorId, savedRfpIds, showToast],
@@ -393,6 +409,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
       setProfileState(p);
       showToast("Profile saved.");
+      captureEvent("profile_saved", { contractor_id: contractorId });
     },
     [contractorId, showToast],
   );
@@ -426,6 +443,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const signOut = useCallback(async () => {
     const supabase = createClient();
     await supabase.auth.signOut();
+    resetPosthog();
     window.location.href = "/login";
   }, []);
 

--- a/web/lib/analytics.ts
+++ b/web/lib/analytics.ts
@@ -1,0 +1,134 @@
+import posthog from "posthog-js";
+
+export type ListCardLayout = "score_first" | "headline_first";
+
+/** RFP list card A/B: `score_first` (prominent match ring) vs `headline_first` (title/agency lead). */
+export function getListCardLayout(): ListCardLayout {
+  const v = process.env.NEXT_PUBLIC_LIST_CARD_LAYOUT?.toLowerCase();
+  return v === "score_first" ? "score_first" : "headline_first";
+}
+
+function baseProps(): Record<string, string> {
+  return { list_card_layout: getListCardLayout() };
+}
+
+let posthogInitialized = false;
+
+type Queued =
+  | { kind: "capture"; event: string; properties?: Record<string, unknown> }
+  | {
+      kind: "identify";
+      distinctId: string;
+      properties?: Record<string, unknown>;
+    };
+
+const queue: Queued[] = [];
+const MAX_QUEUE = 100;
+
+function flushQueue(): void {
+  while (queue.length > 0) {
+    const item = queue.shift()!;
+    if (item.kind === "capture") {
+      try {
+        posthog.capture(item.event, {
+          ...baseProps(),
+          ...item.properties,
+        });
+      } catch {
+        /* ignore */
+      }
+    } else {
+      try {
+        posthog.identify(item.distinctId, {
+          ...baseProps(),
+          ...item.properties,
+        });
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+}
+
+function enqueue(item: Queued): void {
+  if (queue.length >= MAX_QUEUE) {
+    queue.shift();
+  }
+  queue.push(item);
+}
+
+/** Initialize from explicit config (e.g. after /api/posthog-config fetch on Vercel). */
+export function initPosthogWithConfig(
+  apiKey: string,
+  apiHost?: string | null,
+): void {
+  if (typeof window === "undefined") return;
+  if (posthogInitialized) return;
+  const trimmed = apiKey.trim();
+  if (!trimmed) return;
+  const host =
+    (apiHost && apiHost.trim()) ||
+    process.env.NEXT_PUBLIC_POSTHOG_HOST ||
+    "https://us.i.posthog.com";
+  posthog.init(trimmed, {
+    api_host: host,
+    person_profiles: "identified_only",
+    capture_pageview: true,
+    capture_pageleave: true,
+  });
+  posthogInitialized = true;
+  flushQueue();
+}
+
+/** Initialize from NEXT_PUBLIC_* (build-time inlining; typical for local .env.local). */
+export function initPosthog(): void {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  if (!key) return;
+  initPosthogWithConfig(key, process.env.NEXT_PUBLIC_POSTHOG_HOST);
+}
+
+export function captureEvent(
+  event: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") return;
+  if (!posthogInitialized) {
+    enqueue({ kind: "capture", event, properties });
+    return;
+  }
+  try {
+    posthog.capture(event, { ...baseProps(), ...properties });
+  } catch {
+    /* ignore analytics errors */
+  }
+}
+
+export function identifySessionUser(
+  distinctId: string,
+  properties?: Record<string, unknown>,
+): void {
+  if (typeof window === "undefined") return;
+  if (!posthogInitialized) {
+    enqueue({ kind: "identify", distinctId, properties });
+    return;
+  }
+  try {
+    posthog.identify(distinctId, {
+      ...baseProps(),
+      ...properties,
+    });
+  } catch {
+    /* ignore */
+  }
+}
+
+export function resetPosthog(): void {
+  if (typeof window === "undefined") return;
+  if (!posthogInitialized) return;
+  queue.length = 0;
+  try {
+    posthog.reset();
+  } catch {
+    /* ignore */
+  }
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,12 +8,17 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/groq": "^3.0.39",
+        "@ai-sdk/openai": "^3.0.63",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.89.0",
         "@tailwindcss/typography": "^0.5.19",
+        "ai": "^6.0.177",
         "next": "^16.2.4",
+        "posthog-js": "^1.372.10",
         "react-markdown": "^10.1.0",
-        "react-pdf": "^10.4.1"
+        "react-pdf": "^10.4.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -24,6 +29,84 @@
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
         "typescript": "^5"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.112",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.112.tgz",
+      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@vercel/oidc": "3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/groq": {
+      "version": "3.0.39",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/groq/-/groq-3.0.39.tgz",
+      "integrity": "sha512-BZAr6DjCbzWQ0Qn1/TSsHo/bmCt4JaAMb4A7HCSUZBQCAcOjne/03D0sVjHnQhUC3TpwcmYiv7tHAviK7BluRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.63",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.63.tgz",
+      "integrity": "sha512-4yY/m8a57MNNVoJCsXuNblKf6BO4yuAuLKRX4tzSNffBEBSp1FlcWdPE0Z4FkqUeS0AJhYSSqp0GIiA/cIcDNA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz",
+      "integrity": "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.27",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.27.tgz",
+      "integrity": "sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.10",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1493,11 +1576,342 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.28.4",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.28.4.tgz",
+      "integrity": "sha512-wmtUYHYqA3zIAKDKvYWRNWAQsWOIBwxV08e+bWzVy0wQQzpaS/LzzRupXWRMRrLOk+1x3JKFxbqA3n0QGvpqsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.372.10"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.372.10",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.372.10.tgz",
+      "integrity": "sha512-KuT3vLu3LSFsNWCwasS4gqjH/ysAyIUcB/aJSmKyNhDd/85hAznHRz1eSSl0sMvtsDTYiQIq0I0ybduVbrpPew==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
@@ -1990,6 +2404,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -2576,6 +2997,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.2.0.tgz",
+      "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -2597,6 +3027,33 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.177",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.177.tgz",
+      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.112",
+        "@ai-sdk/provider": "3.0.10",
+        "@ai-sdk/provider-utils": "4.0.27",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/ai/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ajv": {
@@ -3168,6 +3625,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3378,6 +3846,15 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.2.tgz",
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/dunder-proto": {
@@ -4039,6 +4516,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4105,6 +4591,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5160,6 +5652,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -5530,6 +6028,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6753,6 +7257,37 @@
         "node": ">=4"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.372.10",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.372.10.tgz",
+      "integrity": "sha512-ZQslIenDM8UpwKhmeeEnJ+t2nXr8mOIjCG+Ej3DCJnTBk9NX9Sr5RMuwHeGG8UJitwvtGOADyiY7DignOXaZwg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.28.4",
+        "@posthog/types": "1.372.10",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6785,6 +7320,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6794,6 +7353,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -8105,6 +8670,12 @@
         "loose-envify": "^1.0.0"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8262,10 +8833,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/web/package.json
+++ b/web/package.json
@@ -9,12 +9,17 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/groq": "^3.0.39",
+    "@ai-sdk/openai": "^3.0.63",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.89.0",
     "@tailwindcss/typography": "^0.5.19",
+    "ai": "^6.0.177",
     "next": "^16.2.4",
+    "posthog-js": "^1.372.10",
     "react-markdown": "^10.1.0",
-    "react-pdf": "^10.4.1"
+    "react-pdf": "^10.4.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
- Add PostHog provider, analytics helpers, and event capture on auth, nav, RFP selection, detail tabs, saves, profile, walkthrough
- Add headline_first vs score_first RFP card layouts via env
- Runtime PostHog bootstrap via POSTHOG_PROJECT_API_KEY and GET /api/posthog-config
- Document analytics and A/B in web README and .env.example