### PR TITLE
web feat: track and display recently viewed RFPs

### DIFF
--- a/supabase/migrations/20260528000001_viewed_rfps.sql
+++ b/supabase/migrations/20260528000001_viewed_rfps.sql
@@ -1,0 +1,29 @@
+-- Track which RFPs each contractor has viewed, with a timestamp so we can
+-- sort by most-recently-viewed and persist history across sessions/devices.
+
+create table public.viewed_rfps (
+    id            uuid        primary key default gen_random_uuid(),
+    contractor_id uuid        not null references public.contractors(id) on delete cascade,
+    rfp_id        uuid        not null references public.rfps(id) on delete cascade,
+    viewed_at     timestamptz not null default now(),
+    unique (contractor_id, rfp_id)
+);
+
+create index viewed_rfps_contractor_viewed_at_idx
+    on public.viewed_rfps (contractor_id, viewed_at desc);
+
+alter table public.viewed_rfps enable row level security;
+
+create policy "viewed_rfps_all_own"
+    on public.viewed_rfps for all
+    to authenticated
+    using (
+        contractor_id in (
+            select id from public.contractors where user_id = auth.uid()
+        )
+    )
+    with check (
+        contractor_id in (
+            select id from public.contractors where user_id = auth.uid()
+        )
+    );

--- a/web/components/RfpFeed.tsx
+++ b/web/components/RfpFeed.tsx
@@ -62,17 +62,6 @@ export function RfpFeed() {
     return feedRfps.slice(start, start + pageSize);
   }, [feedRfps, currentPage, pageSize]);
 
-  if (activeNav === "history") {
-    return (
-      <div className="flex min-h-[200px] flex-1 flex-col items-center justify-center gap-2 bg-govbid-surface px-6 py-12 text-center">
-        <p className="max-w-sm text-sm font-medium text-govbid-text">History</p>
-        <p className="max-w-sm text-sm text-govbid-text-muted">
-          Recently viewed RFPs will appear here once session tracking is connected.
-        </p>
-      </div>
-    );
-  }
-
   return (
     <div
       id="rfp-feed"
@@ -92,14 +81,16 @@ export function RfpFeed() {
         ))}
         {feedRfps.length === 0 && (
           <p className="rounded-xl border border-dashed border-govbid-border bg-govbid-surface/80 px-4 py-10 text-center text-sm leading-relaxed text-govbid-text-muted">
-            {activeNav === "saved"
-              ? "No saved opportunities match these filters. Save RFPs from the detail view or clear filters."
-              : loadedRfps.length === 0
-                ? "Supabase returned no rows for this query (status = active and is_relevant = true). Add or update RFPs in the database, or set is_relevant / status so they match."
-                : filtersActive(searchQuery, rfpFilter) &&
-                    filteredRfps.length === 0
-                  ? `Your catalog has ${loadedRfps.length} RFP(s) from the database, but search and sidebar filters hide all of them. Clear filters or broaden your search.`
-                  : "No RFPs match your search. Try different keywords or filters."}
+            {activeNav === "history"
+              ? "No recently viewed RFPs yet. Open an RFP from the dashboard to start building your history."
+              : activeNav === "saved"
+                ? "No saved opportunities match these filters. Save RFPs from the detail view or clear filters."
+                : loadedRfps.length === 0
+                  ? "Supabase returned no rows for this query (status = active and is_relevant = true). Add or update RFPs in the database, or set is_relevant / status so they match."
+                  : filtersActive(searchQuery, rfpFilter) &&
+                      filteredRfps.length === 0
+                    ? `Your catalog has ${loadedRfps.length} RFP(s) from the database, but search and sidebar filters hide all of them. Clear filters or broaden your search.`
+                    : "No RFPs match your search. Try different keywords or filters."}
           </p>
         )}
       </div>

--- a/web/context/DashboardContext.tsx
+++ b/web/context/DashboardContext.tsx
@@ -69,6 +69,7 @@ type DashboardContextValue = {
   selectRfp: (id: string | null) => void;
   selectedRfp: Rfp | null;
   savedRfpIds: string[];
+  recentlyViewedIds: string[];
   savedRfpRecords: SavedRfpRecord[];
   isSaved: (id: string) => boolean;
   toggleSaveRfp: (id: string) => Promise<void>;
@@ -144,6 +145,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [filtersPanelVisible, setFiltersPanelVisibleState] = useState(true);
   const [toast, setToast] = useState<string | null>(null);
   const [activeNav, setActiveNavState] = useState<ActiveNav>("dashboard");
+  const [recentlyViewedIds, setRecentlyViewedIds] = useState<string[]>([]);
 
   useEffect(() => {
     setFiltersPanelVisibleState(readFiltersPanelVisible());
@@ -262,6 +264,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           })),
         );
 
+        const { data: viewedRows } = await supabase
+          .from("viewed_rfps")
+          .select("rfp_id")
+          .eq("contractor_id", cid)
+          .order("viewed_at", { ascending: false })
+          .limit(50);
+        setRecentlyViewedIds(viewedRows?.map((r) => r.rfp_id) ?? []);
+
         const { data: scoreRows } = await supabase
           .from("scores")
           .select("*")
@@ -323,6 +333,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setContractorId(null);
     setLoadedRfps([]);
     setSavedRfpRecords([]);
+    setRecentlyViewedIds([]);
     setProfileState(defaultContractorProfile);
     setSelectedRfpId(null);
     setUnscoredRfpIds(new Set());
@@ -431,8 +442,13 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       const saved = new Set(savedRfpIds);
       return filteredRfps.filter((r) => saved.has(r.id));
     }
-    return [] as Rfp[];
-  }, [activeNav, filteredRfps, savedRfpIds]);
+    // history: show in most-recently-viewed order, unfiltered
+    const rfpMap = new Map(loadedRfps.map((r) => [r.id, r]));
+    return recentlyViewedIds.flatMap((id) => {
+      const rfp = rfpMap.get(id);
+      return rfp ? [rfp] : [];
+    });
+  }, [activeNav, filteredRfps, savedRfpIds, loadedRfps, recentlyViewedIds]);
 
   useEffect(() => {
     if (selectedRfpId == null) return;
@@ -525,6 +541,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     (id: string | null) => {
       if (id) {
         captureEvent("rfp_selected", { rfp_id: id });
+        setRecentlyViewedIds((prev) => [id, ...prev.filter((x) => x !== id)].slice(0, 50));
+        if (contractorId) {
+          const supabase = createClient();
+          void supabase.from("viewed_rfps").upsert(
+            { contractor_id: contractorId, rfp_id: id, viewed_at: new Date().toISOString() },
+            { onConflict: "contractor_id,rfp_id" },
+          );
+        }
         // Always re-score on click: forces a fresh computation against the
         // current contractor profile so the displayed factor breakdown is
         // current even if the underlying RFP or profile state has shifted
@@ -533,7 +557,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       }
       setSelectedRfpId(id);
     },
-    [ensureScored],
+    [ensureScored, contractorId],
   );
 
   const isSaved = useCallback(
@@ -879,6 +903,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       selectRfp,
       selectedRfp,
       savedRfpIds,
+      recentlyViewedIds,
       savedRfpRecords,
       isSaved,
       toggleSaveRfp,
@@ -918,6 +943,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       selectRfp,
       selectedRfp,
       savedRfpIds,
+      recentlyViewedIds,
       savedRfpRecords,
       isSaved,
       toggleSaveRfp,

--- a/web/lib/database.types.ts
+++ b/web/lib/database.types.ts
@@ -250,6 +250,23 @@ export interface Database {
         Relationships: []
       }
 
+      viewed_rfps: {
+        Row: {
+          id: string
+          contractor_id: string
+          rfp_id: string
+          viewed_at: string
+        }
+        Insert: {
+          id?: string
+          contractor_id: string
+          rfp_id: string
+          viewed_at?: string
+        }
+        Update: Partial<Database['public']['Tables']['viewed_rfps']['Insert']>
+        Relationships: []
+      }
+
       saved_rfps: {
         Row: {
           contractor_id: string


### PR DESCRIPTION
- Add viewed_rfps migration (table + RLS policy)
- Fetch and persist view history in DashboardContext
- Wire history nav to show most-recently-viewed RFPs