### PR TITLE
feat: summary gen improvements + formatting

### DIFF
--- a/processor/pdf_extract.py
+++ b/processor/pdf_extract.py
@@ -19,6 +19,7 @@ Strategy:
 from __future__ import annotations
 
 import io
+import json
 import os
 import re
 from pathlib import Path
@@ -26,6 +27,7 @@ from typing import Any, Iterable, Optional
 
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 _DEFAULT_CACHE_DIR = _PROJECT_ROOT / "scraper" / "cache" / "samgov" / "pdf_text"
+_MAX_EXTRACTED_DOC_CHARS = 80_000
 
 # Attachment labels that aren't the actual spec.
 _DOC_LABEL_BLOCKLIST = (
@@ -81,9 +83,20 @@ def _doc_kind(label: str, url: str) -> Optional[str]:
     return "pdf"
 
 
-def _rank_documents(documents: list[dict[str, Any]]) -> list[tuple[str, dict[str, Any]]]:
+def _rank_documents(
+    documents: list[dict[str, Any]],
+    *,
+    include_addenda: bool = False,
+) -> list[tuple[str, dict[str, Any]]]:
     """Return ``(kind, doc)`` tuples in best-spec-first order, dropping
     obviously admin attachments and unreadable formats."""
+    blocklist = _DOC_LABEL_BLOCKLIST
+    if include_addenda:
+        blocklist = tuple(
+            item for item in _DOC_LABEL_BLOCKLIST
+            if item not in {"addendum", "amendment"}
+        )
+
     candidates: list[tuple[int, str, dict[str, Any]]] = []
     for doc in documents or []:
         if not isinstance(doc, dict):
@@ -96,7 +109,7 @@ def _rank_documents(documents: list[dict[str, Any]]) -> list[tuple[str, dict[str
         if not kind:
             continue
         low = label.lower()
-        if any(bad in low for bad in _DOC_LABEL_BLOCKLIST):
+        if any(bad in low for bad in blocklist):
             continue
         score = 0
         if doc.get("type") == "primary_spec":
@@ -485,6 +498,82 @@ def extract_text_for_record(
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path.write_text(text or "", encoding="utf-8")
     return text or ""
+
+
+def extract_document_texts_for_record(
+    raw: dict[str, Any],
+    *,
+    cache_dir: os.PathLike[str] | str = _DEFAULT_CACHE_DIR,
+    max_docs: int = 5,
+    max_pages: int = 30,
+    refresh: bool = False,
+) -> list[dict[str, str]]:
+    """Return extracted text for the best readable RFP attachments.
+
+    The legacy :func:`extract_text_for_record` returns one text blob for the
+    highest-ranked spec document. Summary generation benefits from more context:
+    main specs, exhibits, and addenda can each contain dates or evaluation
+    language. This helper extracts several ranked readable documents and caches
+    the structured result next to the legacy text cache.
+    """
+    external_id = (raw.get("external_id") or "").strip()
+    cache_path = Path(cache_dir) / f"{_safe_cache_key(external_id)}.documents.json"
+    if not refresh and cache_path.is_file():
+        try:
+            cached = json.loads(cache_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            cached = None
+        if isinstance(cached, list):
+            out: list[dict[str, str]] = []
+            for item in cached:
+                if not isinstance(item, dict):
+                    continue
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    out.append({
+                        "label": str(item.get("label") or "Attached document"),
+                        "type": str(item.get("type") or ""),
+                        "url": str(item.get("url") or ""),
+                        "source_url": str(item.get("source_url") or ""),
+                        "text": text,
+                    })
+            return out
+
+    documents = ((raw.get("metadata") or {}).get("documents")) or []
+    ranked = _rank_documents(documents, include_addenda=True)
+    extracted: list[dict[str, str]] = []
+
+    for kind, doc in ranked:
+        if len(extracted) >= max_docs:
+            break
+        url = doc.get("source_url") or doc.get("url")
+        if not url:
+            continue
+        data = _download_bytes(url)
+        if not data:
+            continue
+        if kind == "pdf":
+            text = _extract_text_from_pdf_bytes(data, max_pages=max_pages)
+        elif kind == "docx":
+            text = _extract_text_from_docx_bytes(data)
+        else:
+            text = ""
+        if not text or len(text) < 200:
+            continue
+        extracted.append({
+            "label": str(doc.get("label") or "Attached document"),
+            "type": str(doc.get("type") or kind),
+            "url": str(doc.get("url") or ""),
+            "source_url": str(doc.get("source_url") or ""),
+            "text": text[:_MAX_EXTRACTED_DOC_CHARS],
+        })
+
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_text(
+        json.dumps(extracted, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return extracted
 
 
 def maybe_backfill_description(raw: dict[str, Any], **kwargs: Any) -> bool:

--- a/processor/pipeline.py
+++ b/processor/pipeline.py
@@ -16,7 +16,10 @@ from processor.enrich import EnrichmentCallback, enrich
 from processor.llm_summarize import summarize_with_llm
 from processor.location import detect_location
 from processor.normalize import normalize_record
-from processor.pdf_extract import extract_text_for_record, maybe_backfill_description
+from processor.pdf_extract import (
+    extract_document_texts_for_record,
+    maybe_backfill_description,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_INPUT_DIR = PROJECT_ROOT / "data_raw"
@@ -75,13 +78,19 @@ def process_one(
 
     # Pull PDF / DOCX scope text up front so we can pass it to the LLM as
     # additional context, regardless of whether the inline description was
-    # empty. ``extract_text_for_record`` is cached on disk, so this is cheap
-    # on re-runs.
+    # empty. Extraction is cached on disk, so this is cheap on re-runs.
+    document_texts: list[dict[str, str]] = []
     pdf_text = ""
     if use_llm_summary:
         try:
-            pdf_text = extract_text_for_record(raw) or ""
+            document_texts = extract_document_texts_for_record(raw)
+            pdf_text = "\n\n".join(
+                f"{entry.get('label') or 'Attached document'}\n{entry.get('text') or ''}"
+                for entry in document_texts
+                if entry.get("text")
+            )
         except Exception:
+            document_texts = []
             pdf_text = ""
 
     normalized = normalize_record(raw)
@@ -94,6 +103,11 @@ def process_one(
         classifier=classifier,
     )
     merged = {**normalized, **enriched}
+    if document_texts:
+        metadata = dict(merged.get("metadata") or {})
+        metadata["extracted_document_texts"] = document_texts
+        metadata["extracted_document_text"] = pdf_text
+        merged["metadata"] = metadata
 
     # Override the deterministic description + statement_of_work with the
     # LLM-generated versions when available. Falls back silently to the

--- a/web/.env.example
+++ b/web/.env.example
@@ -18,6 +18,8 @@ NEXT_PUBLIC_LIST_CARD_LAYOUT=headline_first
 # Server-only: writes `rfp_chunks`, past-project `embedding`, and `rfp_summaries` (RLS blocks anon/authenticated inserts).
 SUPABASE_SERVICE_ROLE_KEY=
 
+SUPABASE_SECRET_KEY=
+
 # Server-only: profile-suggest + RAG embeddings (text-embedding-3-small; never expose as NEXT_PUBLIC_*).
 OPENAI_API_KEY=
 

--- a/web/app/api/rag-summary/route.ts
+++ b/web/app/api/rag-summary/route.ts
@@ -181,6 +181,10 @@ export async function POST(req: Request) {
       id: rfpRow.id,
       title: rfpRow.title,
       description: rfpRow.description,
+      statement_of_work: rfpRow.statement_of_work,
+      deliverables: rfpRow.deliverables,
+      metadata: rfpRow.metadata,
+      raw_data: rfpRow.raw_data,
     });
     const { updated } = await ensurePastProjectsEmbedded(admin, contractor_id);
     if (updated > 0) {

--- a/web/app/api/summary/route.ts
+++ b/web/app/api/summary/route.ts
@@ -2,15 +2,235 @@ import type { NextRequest } from "next/server";
 import OpenAI from "openai";
 import { zodTextFormat } from "openai/helpers/zod";
 
-import { RfpSummarySchema, SummaryRequestSchema } from "@/lib/rfpSummary";
+import type { Database, Json } from "@/lib/database.types";
+import {
+  DETAILED_SUMMARY_PROMPT_VERSION,
+  GENERAL_SUMMARY_TYPE,
+  RfpSummarySchema,
+  SummaryRequestSchema,
+} from "@/lib/rfpSummary";
+import { createServiceRoleClient } from "@/lib/supabase/admin";
+import { createClient } from "@/lib/supabase/server";
 
 const SYSTEM_INSTRUCTIONS = [
   "You summarize US government RFPs (Requests for Proposal) for prospective contractors.",
-  "Only use facts that are explicitly present in the provided RFP text.",
-  "Do not speculate, infer, or pull information from outside the RFP text.",
-  "If a field is not stated in the RFP, return 'unknown' for strings or an empty array for lists.",
-  "Every deadline and evaluation criterion must include a verbatim citation quote copied from the RFP text.",
+  "Only use facts that are explicitly present in the provided RFP database record, extracted attachment text, or indexed RFP chunks.",
+  "Do not speculate, infer, or pull information from outside the provided material.",
+  "If a field is not stated in the provided material, return 'unknown' for strings or an empty array for lists.",
+  "Canonical database fields are source material too; if a canonical line says 'Due date: ...' or 'Contact email: ...', you may cite that exact line.",
+  "Every deadline, evaluation criterion, contract detail, technical work area, submission instruction, contact, and opportunity-posture claim must include a verbatim citation quote copied from the provided material.",
+  "Actively look for opportunity posture signals: RFI, sources sought, market research, presolicitation, notice of intent, sole source, intended awardee, incumbent, follow-on, recompete, set-aside, and competition caveats.",
+  "Actively look for contract mechanics: solicitation number, notice type, NAICS, PSC, set-aside, contract type, pricing, period of performance, option periods, extension periods, place of performance, agency office, size standard, authority, and intended awardee.",
+  "Actively look for technical work areas: named systems, platforms, software/toolsets, maintenance/sustainment tasks, modernization/migration tasks, security requirements, clearances, support volumes, SLAs, ticketing tools, audit logging, role-based security, patching, upgrades, and deliverables.",
+  "Actively look for submission guidance: what vendors should submit, deadline, email/portal, page limits, format, whether submissions will only inform market research or a competition decision, and whether the government will pay for responses.",
 ].join(" ");
+
+const MAX_CONTEXT_CHARS = 200_000;
+const MAX_SECTION_CHARS = 80_000;
+const PDF_URL_KEYS = [
+  "pdf_url_1",
+  "pdf_url_2",
+  "pdf_url_3",
+  "pdf_url_4",
+  "pdf_url_5",
+  "pdf_url_6",
+  "pdf_url_7",
+  "pdf_url_8",
+  "pdf_url_9",
+  "pdf_url_10",
+] as const;
+
+type RfpRow = Database["public"]["Tables"]["rfps"]["Row"];
+type RfpChunkRow = Pick<
+  Database["public"]["Tables"]["rfp_chunks"]["Row"],
+  "chunk_index" | "chunk_text" | "metadata"
+>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function displayValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => displayValue(item))
+      .filter(Boolean)
+      .join(", ");
+  }
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return "";
+  return JSON.stringify(record);
+}
+
+function line(label: string, value: unknown): string | null {
+  const text = displayValue(value);
+  return text ? `${label}: ${text}` : null;
+}
+
+function pushSection(parts: string[], title: string, body: string): void {
+  const trimmed = body.trim();
+  if (!trimmed) return;
+  parts.push(`## ${title}\n${trimmed.slice(0, MAX_SECTION_CHARS)}`);
+}
+
+function compactJson(value: unknown): string {
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return "";
+  }
+}
+
+function withoutLargeTextFields(record: Record<string, unknown>) {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      key === "documents" ||
+      key === "extracted_document_text" ||
+      key === "extracted_document_texts"
+    ) {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function documentLines(metadata: Record<string, unknown>, row: RfpRow): string {
+  const lines: string[] = [];
+  const docs = asArray(metadata.documents);
+  docs.forEach((value, index) => {
+    const doc = asRecord(value);
+    const fields = [
+      line("label", doc.label),
+      line("type", doc.type),
+      line("description", doc.attachment_description),
+      line("source_url", doc.source_url),
+      line("drive_url", doc.url),
+      line("size_bytes", doc.size_bytes),
+    ].filter((item): item is string => Boolean(item));
+    if (fields.length) {
+      lines.push(`Document ${index + 1}: ${fields.join("; ")}`);
+    }
+  });
+
+  PDF_URL_KEYS.forEach((key) => {
+    const url = row[key];
+    if (typeof url === "string" && url.trim()) {
+      lines.push(`${key}: ${url.trim()}`);
+    }
+  });
+
+  return Array.from(new Set(lines)).join("\n");
+}
+
+function extractedDocumentText(metadata: Record<string, unknown>): string {
+  const blocks: string[] = [];
+  for (const value of asArray(metadata.extracted_document_texts)) {
+    const entry = asRecord(value);
+    const text = cleanString(entry.text);
+    if (!text) continue;
+    const label = cleanString(entry.label) || "Attached document";
+    const type = cleanString(entry.type);
+    blocks.push(
+      [`### ${label}${type ? ` (${type})` : ""}`, text].join("\n"),
+    );
+  }
+
+  const singleText = cleanString(metadata.extracted_document_text);
+  if (singleText && !blocks.some((block) => block.includes(singleText.slice(0, 100)))) {
+    blocks.push(`### Extracted attachment text\n${singleText}`);
+  }
+
+  return blocks.join("\n\n---\n\n");
+}
+
+function buildRfpContext(row: RfpRow, chunks: RfpChunkRow[]): string {
+  const metadata = asRecord(row.metadata as Json | null);
+  const rawData = asRecord(row.raw_data as Json | null);
+  const rawMetadata = asRecord(rawData.metadata);
+  const combinedMetadata = { ...rawMetadata, ...metadata };
+  const parts: string[] = [];
+
+  pushSection(
+    parts,
+    "Canonical RFP Fields",
+    [
+      line("Source", row.source),
+      line("External ID", row.external_id),
+      line("Title", row.title),
+      line("Short name", row.name),
+      line("Department / agency", row.department),
+      line("Status", row.status),
+      line("Posted date", row.posted_date),
+      line("Due date", row.due_date),
+      line("Location", row.location),
+      line("State", row.state),
+      line("Location level", row.location_level),
+      line("Contract amount minimum", row.contract_amount_min),
+      line("Contract amount maximum", row.contract_amount_max),
+      line("Tags", row.tags),
+      line("Contact name", row.contact_name),
+      line("Contact email", row.contact_email),
+      line("Contact phone", row.contact_phone),
+    ]
+      .filter((item): item is string => Boolean(item))
+      .join("\n"),
+  );
+
+  pushSection(parts, "Description", row.description ?? "");
+  pushSection(parts, "Statement of Work", row.statement_of_work ?? "");
+  pushSection(parts, "Deliverables", (row.deliverables ?? []).join("\n"));
+  pushSection(parts, "Attached Documents", documentLines(combinedMetadata, row));
+  pushSection(
+    parts,
+    "Source Metadata",
+    compactJson(withoutLargeTextFields(combinedMetadata)),
+  );
+  pushSection(
+    parts,
+    "Extracted Attachment Text",
+    extractedDocumentText(combinedMetadata),
+  );
+
+  if (chunks.length > 0) {
+    pushSection(
+      parts,
+      "Indexed RFP Chunks",
+      chunks
+        .sort((a, b) => a.chunk_index - b.chunk_index)
+        .map((chunk) => {
+          const meta = compactJson(chunk.metadata);
+          return [
+            `### Chunk ${chunk.chunk_index}`,
+            meta ? `Metadata: ${meta}` : "",
+            chunk.chunk_text,
+          ]
+            .filter(Boolean)
+            .join("\n");
+        })
+        .join("\n\n---\n\n"),
+    );
+  }
+
+  return parts.join("\n\n").slice(0, MAX_CONTEXT_CHARS);
+}
 
 export async function POST(request: NextRequest) {
   let rawBody: unknown;
@@ -33,7 +253,8 @@ export async function POST(request: NextRequest) {
       { status: 400 }
     );
   }
-  const { rfpText, rfpTitle } = parsedBody.data;
+  let { rfpText, rfpTitle } = parsedBody.data;
+  const { rfpId } = parsedBody.data;
 
   const apiKey = process.env.OPENAI_API_KEY;
   if (!apiKey) {
@@ -43,12 +264,88 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  let cacheTarget: { rfpId: string; admin: ReturnType<typeof createServiceRoleClient> } | null = null;
+
+  if (rfpId) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return Response.json({ error: "Unauthorized." }, { status: 401 });
+    }
+
+    let admin: ReturnType<typeof createServiceRoleClient>;
+    try {
+      admin = createServiceRoleClient();
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Server misconfiguration.";
+      return Response.json(
+        {
+          error:
+            `${message}. Regenerating summaries requires a server-only Supabase secret so the result can be saved.`,
+        },
+        { status: 503 },
+      );
+    }
+    const dataClient = admin;
+    cacheTarget = { rfpId, admin };
+
+    await admin
+      .from("rfp_summaries")
+      .delete()
+      .eq("rfp_id", rfpId)
+      .eq("summary_type", GENERAL_SUMMARY_TYPE)
+      .is("prompt_version", null);
+    await admin
+      .from("rfp_summaries")
+      .delete()
+      .eq("rfp_id", rfpId)
+      .eq("summary_type", GENERAL_SUMMARY_TYPE)
+      .neq("prompt_version", DETAILED_SUMMARY_PROMPT_VERSION);
+
+    const { data: row, error: rfpErr } = await dataClient
+      .from("rfps")
+      .select("*")
+      .eq("id", rfpId)
+      .maybeSingle();
+
+    if (rfpErr || !row) {
+      return Response.json(
+        { error: rfpErr?.message ?? "RFP not found." },
+        { status: 404 },
+      );
+    }
+
+    const { data: chunks, error: chunksErr } = await dataClient
+      .from("rfp_chunks")
+      .select("chunk_index, chunk_text, metadata")
+      .eq("rfp_id", rfpId)
+      .order("chunk_index", { ascending: true });
+
+    if (chunksErr) {
+      return Response.json({ error: chunksErr.message }, { status: 502 });
+    }
+
+    rfpTitle = row.title;
+    rfpText = buildRfpContext(row, chunks ?? []);
+  }
+
+  if (!rfpText?.trim()) {
+    return Response.json(
+      { error: "No RFP text was available for summary generation." },
+      { status: 400 },
+    );
+  }
+
   const client = new OpenAI({ apiKey });
   const model = "gpt-4.1-mini";
 
   const userContent = [
     rfpTitle ? `RFP Title: ${rfpTitle}` : null,
-    "RFP Text:",
+    "Extract a bidder-facing structured summary. Include opportunity posture, contract details, technical work areas, submission guidance, critical deadlines, evaluation criteria, and points of contact when stated.",
+    "RFP database record, extracted attachment text, and indexed RFP text:",
     '"""',
     rfpText,
     '"""',
@@ -75,6 +372,33 @@ export async function POST(request: NextRequest) {
         },
         { status: 502 }
       );
+    }
+
+    const summaryJson = JSON.stringify(response.output_parsed);
+
+    if (cacheTarget) {
+      const { error: upsertErr } = await cacheTarget.admin
+        .from("rfp_summaries")
+        .upsert(
+          {
+            rfp_id: cacheTarget.rfpId,
+            summary: summaryJson,
+            summary_type: GENERAL_SUMMARY_TYPE,
+            model,
+            prompt_version: DETAILED_SUMMARY_PROMPT_VERSION,
+            generated_at: new Date().toISOString(),
+          },
+          { onConflict: "rfp_id,summary_type,prompt_version" },
+        );
+
+      if (upsertErr) {
+        return Response.json(
+          {
+            error: `Summary generated but could not be saved: ${upsertErr.message}`,
+          },
+          { status: 502 },
+        );
+      }
     }
 
     return Response.json(response.output_parsed);

--- a/web/components/DetailPanel.tsx
+++ b/web/components/DetailPanel.tsx
@@ -9,6 +9,7 @@ import { isPdfUrl } from "@/lib/pdf";
 import type { CompatibilityFactors, Rfp } from "@/lib/types";
 import { RadarChart } from "./RadarChart";
 import { SourceDocumentEmbed } from "./SourceDocumentEmbed";
+import { SummaryBrief } from "./SummaryBrief";
 import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
@@ -232,16 +233,10 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
       action: "generate_summary",
       variant: "A",
       rfp_id: rfp.id,
-      cached: result === "cached",
+      cached: false,
     });
-    if (result === "cached") {
-      showToast("Loaded cached summary. See the Summary tab.");
-      captureEvent("rag_summary_cached_hit", { rfp_id: rfp.id });
-      setTab("summary");
-      return;
-    }
     if (result === "generated") {
-      showToast("Summary generated. See the Summary tab.");
+      showToast("Summary regenerated and saved. See the Summary tab.");
       captureEvent("rag_summary_generated", { rfp_id: rfp.id });
       setTab("summary");
       return;
@@ -419,17 +414,11 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
         )}
 
         {tab === "summary" && (
-          <div className="prose prose-sm prose-slate mx-auto max-w-5xl text-govbid-text">
-            {rfp.summaryMarkdown ? (
-              <ReactMarkdown>{rfp.summaryMarkdown}</ReactMarkdown>
-            ) : (
-              <p className="text-sm italic text-govbid-text-muted">
-                {generating
-                  ? "Generating summary…"
-                  : "No summary yet. Click \"Generate summary\" above to extract scope of work, deadlines, and evaluation criteria from the RFP text."}
-              </p>
-            )}
-          </div>
+          <SummaryBrief
+            content={rfp.summaryMarkdown}
+            generating={generating}
+            emptyMessage='No stored summary yet. Click "Generate summary" above to create and save a detailed bidder brief.'
+          />
         )}
 
         {tab === "match" && (

--- a/web/components/DetailPanelVariantB.tsx
+++ b/web/components/DetailPanelVariantB.tsx
@@ -7,6 +7,7 @@ import { useDashboard } from "@/context/DashboardContext";
 import { isPdfUrl } from "@/lib/pdf";
 import type { Rfp } from "@/lib/types";
 import { SourceDocumentEmbed } from "./SourceDocumentEmbed";
+import { SummaryBrief } from "./SummaryBrief";
 import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
@@ -202,15 +203,10 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
       action: "generate_summary",
       variant: "B",
       rfp_id: rfp.id,
-      cached: result === "cached",
+      cached: false,
     });
-    if (result === "cached") {
-      showToast("Loaded cached summary. See the Summary tab.");
-      setTab("summary");
-      return;
-    }
     if (result === "generated") {
-      showToast("Summary generated. See the Summary tab.");
+      showToast("Summary regenerated and saved. See the Summary tab.");
       setTab("summary");
     }
   };
@@ -451,19 +447,11 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
         )}
 
         {tab === "summary" && (
-          <div className="rounded-xl border border-govbid-border bg-govbid-surface p-4">
-            <div className="prose prose-sm prose-slate max-w-none text-govbid-text">
-              {rfp.summaryMarkdown ? (
-                <ReactMarkdown>{rfp.summaryMarkdown}</ReactMarkdown>
-              ) : (
-                <p className="text-sm italic text-govbid-text-muted">
-                  {generating
-                    ? "Generating summary…"
-                    : "No summary yet. Click the Summary action above to extract scope of work, deadlines, and evaluation criteria from the RFP text."}
-                </p>
-              )}
-            </div>
-          </div>
+          <SummaryBrief
+            content={rfp.summaryMarkdown}
+            generating={generating}
+            emptyMessage="No stored summary yet. Click the Summary action above to create and save a detailed bidder brief."
+          />
         )}
       </div>
     </section>

--- a/web/components/SummaryBrief.tsx
+++ b/web/components/SummaryBrief.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import ReactMarkdown from "react-markdown";
+import { RfpSummarySchema, type RfpSummary } from "@/lib/rfpSummary";
+
+type SummaryBriefProps = {
+  content: string | null;
+  generating?: boolean;
+  emptyMessage: string;
+};
+
+function parseSummary(content: string): RfpSummary | null {
+  try {
+    const parsed = JSON.parse(content);
+    const result = RfpSummarySchema.safeParse(parsed);
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+function Quote({ quote }: { quote: string }) {
+  return (
+    <p className="mt-2 border-l-2 border-govbid-border-strong pl-3 text-xs leading-relaxed text-govbid-text-muted">
+      {quote}
+    </p>
+  );
+}
+
+function FactList({
+  items,
+  empty,
+}: {
+  items: RfpSummary["contract_details"];
+  empty: string;
+}) {
+  if (items.length === 0) {
+    return <p className="text-sm italic text-govbid-text-muted">{empty}</p>;
+  }
+
+  return (
+    <div className="grid gap-3 md:grid-cols-2">
+      {items.map((item, index) => (
+        <div
+          key={`${item.label}-${index}`}
+          className="rounded-lg border border-govbid-border bg-govbid-elevated p-3"
+        >
+          <p className="text-xs font-semibold uppercase text-govbid-text-muted">
+            {item.label}
+          </p>
+          <p className="mt-1 text-sm font-medium leading-relaxed text-govbid-text">
+            {item.detail}
+          </p>
+          <Quote quote={item.citation.quote} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-bold uppercase tracking-wide text-govbid-text">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function StructuredSummary({ summary }: { summary: RfpSummary }) {
+  return (
+    <div className="mx-auto max-w-5xl space-y-6 text-govbid-text">
+      <section className="rounded-lg border border-govbid-border bg-govbid-primary-soft p-4">
+        <p className="text-xs font-semibold uppercase tracking-wide text-govbid-primary">
+          Opportunity posture
+        </p>
+        <p className="mt-2 text-base leading-relaxed">
+          {summary.opportunity_posture || "Not stated in the RFP."}
+        </p>
+        {summary.opportunity_posture_citations.map((citation, index) => (
+          <Quote key={index} quote={citation.quote} />
+        ))}
+      </section>
+
+      <Section title="Scope of Work">
+        <div className="rounded-lg border border-govbid-border bg-govbid-surface p-4">
+          <p className="text-sm leading-relaxed">
+            {summary.scope_of_work || "Not stated in the RFP."}
+          </p>
+          {summary.scope_of_work_citations.map((citation, index) => (
+            <Quote key={index} quote={citation.quote} />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Technical Work Areas">
+        <FactList
+          items={summary.technical_work_areas}
+          empty="No technical work areas stated in the RFP."
+        />
+      </Section>
+
+      <Section title="Contract Details">
+        <FactList
+          items={summary.contract_details}
+          empty="No contract details stated in the RFP."
+        />
+      </Section>
+
+      <Section title="Critical Deadlines">
+        {summary.critical_deadlines.length === 0 ? (
+          <p className="text-sm italic text-govbid-text-muted">
+            No deadlines stated in the RFP.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {summary.critical_deadlines.map((deadline, index) => (
+              <div
+                key={`${deadline.label}-${index}`}
+                className="rounded-lg border border-govbid-border bg-govbid-surface p-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className="text-sm font-semibold text-govbid-text">
+                    {deadline.label}
+                  </p>
+                  <p className="text-sm font-bold text-govbid-primary">
+                    {deadline.date}
+                  </p>
+                </div>
+                <Quote quote={deadline.citation.quote} />
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <Section title="Submission Guidance">
+        <FactList
+          items={summary.submission_guidance}
+          empty="No submission instructions stated in the RFP."
+        />
+      </Section>
+
+      <Section title="Evaluation Criteria">
+        {summary.evaluation_criteria.length === 0 ? (
+          <p className="text-sm italic text-govbid-text-muted">
+            No evaluation criteria stated in the RFP.
+          </p>
+        ) : (
+          <div className="space-y-3">
+            {summary.evaluation_criteria.map((criterion, index) => (
+              <div
+                key={`${criterion.name}-${index}`}
+                className="rounded-lg border border-govbid-border bg-govbid-surface p-3"
+              >
+                <div className="flex flex-wrap items-baseline justify-between gap-2">
+                  <p className="text-sm font-semibold text-govbid-text">
+                    {criterion.name}
+                  </p>
+                  {typeof criterion.weight_pct === "number" && (
+                    <p className="text-xs font-bold text-govbid-primary">
+                      {criterion.weight_pct}%
+                    </p>
+                  )}
+                </div>
+                <p className="mt-1 text-sm leading-relaxed text-govbid-text">
+                  {criterion.description}
+                </p>
+                <Quote quote={criterion.citation.quote} />
+              </div>
+            ))}
+          </div>
+        )}
+      </Section>
+
+      <Section title="Points of Contact">
+        <FactList
+          items={summary.points_of_contact}
+          empty="No points of contact stated in the RFP."
+        />
+      </Section>
+    </div>
+  );
+}
+
+export function SummaryBrief({
+  content,
+  generating = false,
+  emptyMessage,
+}: SummaryBriefProps) {
+  if (!content) {
+    return (
+      <p className="text-sm italic text-govbid-text-muted">
+        {generating ? "Generating summary..." : emptyMessage}
+      </p>
+    );
+  }
+
+  const structured = parseSummary(content);
+  if (structured) {
+    return <StructuredSummary summary={structured} />;
+  }
+
+  return (
+    <div className="prose prose-sm prose-slate mx-auto max-w-5xl text-govbid-text">
+      <ReactMarkdown>{content}</ReactMarkdown>
+    </div>
+  );
+}

--- a/web/context/DashboardContext.tsx
+++ b/web/context/DashboardContext.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/types";
 import { createClient } from "@/lib/supabase/client";
 import {
+  RFP_DASHBOARD_SELECT,
   contractorRowToProfile,
   mapRfpRow,
   profileToContractorUpdate,
@@ -28,7 +29,11 @@ import {
   identifySessionUser,
   resetPosthog,
 } from "@/lib/analytics";
-import { formatRfpSummaryMarkdown, RfpSummarySchema } from "@/lib/rfpSummary";
+import {
+  DETAILED_SUMMARY_PROMPT_VERSION,
+  GENERAL_SUMMARY_TYPE,
+  RfpSummarySchema,
+} from "@/lib/rfpSummary";
 import {
   buildSavedRfpRecordsInOrder,
   nextSortPosition,
@@ -81,13 +86,12 @@ type DashboardContextValue = {
   setProfile: (p: Partial<ContractorProfile>) => void;
   saveProfile: (p: ContractorProfile) => Promise<void>;
   /**
-   * Show the structured summary for an RFP in the AI tab. Returns "cached"
-   * if a row was found in `rfp_summaries`, "generated" if the LLM produced
-   * a fresh summary via /api/summary, or "failed" otherwise.
+   * Regenerate the structured summary for an RFP and persist it in
+   * `rfp_summaries`. Stored summaries are loaded during workspace load.
    */
   loadOrGenerateSummary: (
     rfpId: string,
-  ) => Promise<"cached" | "generated" | "failed">;
+  ) => Promise<"generated" | "failed">;
   /** True while /api/summary is in flight for this RFP. */
   isGeneratingSummary: (rfpId: string) => boolean;
   /** True when a compatibility score is being computed for this RFP. */
@@ -287,7 +291,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
         const { data: rfpRows, error: rfpErr } = await supabase
           .from("rfps")
-          .select("*")
+          .select(RFP_DASHBOARD_SELECT)
           .eq("status", "active")
           .eq("is_relevant", true)
           .order("due_date", { ascending: true, nullsFirst: false });
@@ -298,9 +302,31 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           return;
         }
 
+        const rfpIds = (rfpRows ?? []).map((row) => row.id);
+        const { data: summaryRows, error: summaryErr } = rfpIds.length
+          ? await supabase
+              .from("rfp_summaries")
+              .select("rfp_id, summary")
+              .in("rfp_id", rfpIds)
+              .eq("summary_type", GENERAL_SUMMARY_TYPE)
+              .eq("prompt_version", DETAILED_SUMMARY_PROMPT_VERSION)
+              .order("generated_at", { ascending: false })
+          : { data: null, error: null };
+        if (summaryErr) {
+          console.warn("[summary] stored summary fetch failed:", summaryErr);
+        }
+        const summaryByRfpId = new Map<string, string>();
+        for (const row of summaryRows ?? []) {
+          if (!summaryByRfpId.has(row.rfp_id)) {
+            summaryByRfpId.set(row.rfp_id, row.summary);
+          }
+        }
+
         const mapped =
-          rfpRows?.map((row) => mapRfpRow(row, cid, scoreRows ?? undefined)) ??
-          [];
+          rfpRows?.map((row) => ({
+            ...mapRfpRow(row, cid, scoreRows ?? undefined),
+            summaryMarkdown: summaryByRfpId.get(row.id) ?? null,
+          })) ?? [];
         setLoadedRfps(mapped);
 
         const scoredRfpIds = new Set(
@@ -832,45 +858,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const loadOrGenerateSummary = useCallback(
     async (
       rfpId: string,
-    ): Promise<"cached" | "generated" | "failed"> => {
-      const supabase = createClient();
-      const { data, error } = await supabase
-        .from("rfp_summaries")
-        .select("summary")
-        .eq("rfp_id", rfpId)
-        .eq("summary_type", "general")
-        .order("generated_at", { ascending: false })
-        .limit(1)
-        .maybeSingle();
-      if (!error && data?.summary) {
-        setLoadedRfps((prev) =>
-          prev.map((r) =>
-            r.id === rfpId ? { ...r, summaryMarkdown: data.summary } : r,
-          ),
-        );
-        return "cached";
-      }
-
+    ): Promise<"generated" | "failed"> => {
       if (inFlightSummariesRef.current.has(rfpId)) {
         return "failed";
       }
-
-      const rfp = loadedRfpsRef.current.find((r) => r.id === rfpId);
-      if (!rfp) return "failed";
-
-      const rfpText = [
-        rfp.description,
-        rfp.statementOfWork
-          ? `Statement of Work:\n${rfp.statementOfWork}`
-          : "",
-        rfp.deliverables.length
-          ? `Deliverables:\n- ${rfp.deliverables.join("\n- ")}`
-          : "",
-      ]
-        .filter(Boolean)
-        .join("\n\n")
-        .trim();
-      if (!rfpText) return "failed";
 
       inFlightSummariesRef.current.add(rfpId);
       setSummariesInFlight((prev) => {
@@ -883,7 +874,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         const res = await fetch("/api/summary", {
           method: "POST",
           headers: { "content-type": "application/json" },
-          body: JSON.stringify({ rfpText, rfpTitle: rfp.title }),
+          body: JSON.stringify({ rfpId }),
         });
         if (!res.ok) {
           const errBody = (await res.json().catch(() => null)) as {
@@ -899,10 +890,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           showToast("Summary response was not in the expected shape.");
           return "failed";
         }
-        const markdown = formatRfpSummaryMarkdown(parsed.data);
+        const summaryJson = JSON.stringify(parsed.data);
         setLoadedRfps((prev) =>
           prev.map((r) =>
-            r.id === rfpId ? { ...r, summaryMarkdown: markdown } : r,
+            r.id === rfpId ? { ...r, summaryMarkdown: summaryJson } : r,
           ),
         );
         return "generated";

--- a/web/lib/mappers.ts
+++ b/web/lib/mappers.ts
@@ -6,6 +6,36 @@ type PastProjectRow = Database["public"]["Tables"]["contractor_past_projects"]["
 type RfpRow = Database["public"]["Tables"]["rfps"]["Row"];
 type ScoreRow = Database["public"]["Tables"]["scores"]["Row"];
 
+export const RFP_DASHBOARD_SELECT =
+  "id,title,name,description,statement_of_work,deliverables,location,state,department,due_date,contract_amount_min,contract_amount_max,tags,pdf_url_1,pdf_url_2,pdf_url_3,pdf_url_4,pdf_url_5,pdf_url_6,pdf_url_7,pdf_url_8,pdf_url_9,pdf_url_10" as const;
+
+type RfpMapperRow = Pick<
+  RfpRow,
+  | "id"
+  | "title"
+  | "name"
+  | "description"
+  | "statement_of_work"
+  | "deliverables"
+  | "location"
+  | "state"
+  | "department"
+  | "due_date"
+  | "contract_amount_min"
+  | "contract_amount_max"
+  | "tags"
+  | "pdf_url_1"
+  | "pdf_url_2"
+  | "pdf_url_3"
+  | "pdf_url_4"
+  | "pdf_url_5"
+  | "pdf_url_6"
+  | "pdf_url_7"
+  | "pdf_url_8"
+  | "pdf_url_9"
+  | "pdf_url_10"
+>;
+
 const PDF_URL_KEYS = [
   "pdf_url_1",
   "pdf_url_2",
@@ -19,7 +49,7 @@ const PDF_URL_KEYS = [
   "pdf_url_10",
 ] as const satisfies readonly (keyof RfpRow)[];
 
-export function collectPdfUrlsFromRfpRow(row: RfpRow): string[] {
+export function collectPdfUrlsFromRfpRow(row: RfpMapperRow): string[] {
   const out: string[] = [];
   for (const key of PDF_URL_KEYS) {
     const v = row[key];
@@ -74,7 +104,7 @@ export function pickLatestScoreForRfp(
 }
 
 export function mapRfpRow(
-  row: RfpRow,
+  row: RfpMapperRow,
   contractorId: string,
   scoresForContractor: ScoreRow[] | null | undefined,
   aiOverride?: string,

--- a/web/lib/rfpSummary.ts
+++ b/web/lib/rfpSummary.ts
@@ -1,5 +1,8 @@
 import { z } from "zod";
 
+export const GENERAL_SUMMARY_TYPE = "general";
+export const DETAILED_SUMMARY_PROMPT_VERSION = "detailed-v4";
+
 const Citation = z.object({
   quote: z
     .string()
@@ -38,7 +41,29 @@ const Criterion = z.object({
   citation: Citation,
 });
 
+const SummaryFact = z.object({
+  label: z
+    .string()
+    .describe(
+      "Short label for the fact, e.g. 'Notice type', 'NAICS', 'Submission format', 'Sole-source authority'.",
+    ),
+  detail: z
+    .string()
+    .describe("The factual detail exactly supported by the provided material."),
+  citation: Citation,
+});
+
 export const RfpSummarySchema = z.object({
+  opportunity_posture: z
+    .string()
+    .describe(
+      "A 2-4 sentence explanation of what kind of opportunity this is and how a bidder should interpret it: competitive RFP, RFI/sources sought, sole-source notice, amendment, follow-on/recompete, market research, etc. If not stated, return 'unknown'.",
+    ),
+  opportunity_posture_citations: z
+    .array(Citation)
+    .describe(
+      "One to three verbatim quotes that support the opportunity_posture. Empty array if unknown.",
+    ),
   scope_of_work: z
     .string()
     .describe(
@@ -59,22 +84,59 @@ export const RfpSummarySchema = z.object({
     .describe(
       "All evaluation criteria the RFP states will be used to score proposals. Empty array if none are stated."
     ),
+  contract_details: z
+    .array(SummaryFact)
+    .describe(
+      "Important procurement facts such as solicitation number, notice type, contract type, period of performance, option periods, NAICS, PSC, set-aside, size standard, intended awardee/incumbent, sole-source authority, place of performance, agency office, and pricing basis. Empty array if none are stated.",
+    ),
+  technical_work_areas: z
+    .array(SummaryFact)
+    .describe(
+      "Concrete technical tasks, systems, tools, platforms, support volumes, security requirements, clearances, migration/modernization work, maintenance responsibilities, sustainment duties, and deliverable work areas. Empty array if none are stated.",
+    ),
+  submission_guidance: z
+    .array(SummaryFact)
+    .describe(
+      "Instructions for vendors: what to submit, format, page limits, recipient/contact, submission portal/email, due date, whether submissions only inform market research or competition decisions, and whether the government will pay for responses. Empty array if none are stated.",
+    ),
+  points_of_contact: z
+    .array(SummaryFact)
+    .describe(
+      "Named buyer contacts, contracting officers, emails, and phone numbers. Empty array if none are stated.",
+    ),
 });
 
 export type RfpSummary = z.infer<typeof RfpSummarySchema>;
 
-export const SummaryRequestSchema = z.object({
-  rfpText: z
-    .string()
-    .min(1, "rfpText is required")
-    .max(200_000, "rfpText exceeds 200,000 character limit"),
-  rfpTitle: z.string().max(500).optional(),
-});
+export const SummaryRequestSchema = z
+  .object({
+    rfpId: z.string().uuid().optional(),
+    rfpText: z
+      .string()
+      .min(1, "rfpText is required")
+      .max(200_000, "rfpText exceeds 200,000 character limit")
+      .optional(),
+    rfpTitle: z.string().max(500).optional(),
+  })
+  .refine((value) => Boolean(value.rfpId || value.rfpText), {
+    message: "Either rfpId or rfpText is required",
+    path: ["rfpId"],
+  });
 
 export type SummaryRequest = z.infer<typeof SummaryRequestSchema>;
 
 export function formatRfpSummaryMarkdown(summary: RfpSummary): string {
   const blocks: string[] = [];
+
+  blocks.push("### Opportunity Posture");
+  blocks.push(summary.opportunity_posture || "_Not stated in the RFP._");
+  if (summary.opportunity_posture_citations.length > 0) {
+    blocks.push(
+      summary.opportunity_posture_citations
+        .map((c) => `> ${c.quote}`)
+        .join("\n>\n"),
+    );
+  }
 
   blocks.push("### Scope of Work");
   blocks.push(summary.scope_of_work || "_Not stated in the RFP._");
@@ -83,6 +145,28 @@ export function formatRfpSummaryMarkdown(summary: RfpSummary): string {
       summary.scope_of_work_citations
         .map((c) => `> ${c.quote}`)
         .join("\n>\n"),
+    );
+  }
+
+  blocks.push("### Technical Work Areas");
+  if (summary.technical_work_areas.length === 0) {
+    blocks.push("_No technical work areas stated in the RFP._");
+  } else {
+    blocks.push(
+      summary.technical_work_areas
+        .map((f) => `- **${f.label}** — ${f.detail}\n  > ${f.citation.quote}`)
+        .join("\n"),
+    );
+  }
+
+  blocks.push("### Contract Details");
+  if (summary.contract_details.length === 0) {
+    blocks.push("_No contract details stated in the RFP._");
+  } else {
+    blocks.push(
+      summary.contract_details
+        .map((f) => `- **${f.label}** — ${f.detail}\n  > ${f.citation.quote}`)
+        .join("\n"),
     );
   }
 
@@ -99,6 +183,17 @@ export function formatRfpSummaryMarkdown(summary: RfpSummary): string {
     );
   }
 
+  blocks.push("### Submission Guidance");
+  if (summary.submission_guidance.length === 0) {
+    blocks.push("_No submission instructions stated in the RFP._");
+  } else {
+    blocks.push(
+      summary.submission_guidance
+        .map((f) => `- **${f.label}** — ${f.detail}\n  > ${f.citation.quote}`)
+        .join("\n"),
+    );
+  }
+
   blocks.push("### Evaluation Criteria");
   if (summary.evaluation_criteria.length === 0) {
     blocks.push("_No evaluation criteria stated in the RFP._");
@@ -110,6 +205,17 @@ export function formatRfpSummaryMarkdown(summary: RfpSummary): string {
             typeof c.weight_pct === "number" ? ` (${c.weight_pct}%)` : "";
           return `- **${c.name}**${weight} — ${c.description}\n  > ${c.citation.quote}`;
         })
+        .join("\n"),
+    );
+  }
+
+  blocks.push("### Points of Contact");
+  if (summary.points_of_contact.length === 0) {
+    blocks.push("_No points of contact stated in the RFP._");
+  } else {
+    blocks.push(
+      summary.points_of_contact
+        .map((f) => `- **${f.label}** — ${f.detail}\n  > ${f.citation.quote}`)
         .join("\n"),
     );
   }

--- a/web/lib/server/ragPipeline.ts
+++ b/web/lib/server/ragPipeline.ts
@@ -7,18 +7,80 @@ import { chunkText } from "@/lib/server/textChunk";
 const EMBEDDING_MODEL = openai.embedding("text-embedding-3-small");
 
 type AdminClient = SupabaseClient<Database>;
+type JsonRecord = Record<string, unknown>;
+
+type RfpChunkInput = {
+  id: string;
+  title: string | null;
+  description: string | null;
+  statement_of_work?: string | null;
+  deliverables?: string[] | null;
+  metadata?: unknown;
+  raw_data?: unknown;
+};
+
+function asRecord(value: unknown): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonRecord)
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function extractedDocumentText(metadata: JsonRecord): string {
+  const blocks: string[] = [];
+  for (const value of asArray(metadata.extracted_document_texts)) {
+    const entry = asRecord(value);
+    const text = cleanString(entry.text);
+    if (!text) continue;
+    const label = cleanString(entry.label) || "Attached document";
+    blocks.push(`${label}\n${text}`);
+  }
+
+  const singleText = cleanString(metadata.extracted_document_text);
+  if (singleText && !blocks.some((block) => block.includes(singleText.slice(0, 100)))) {
+    blocks.push(singleText);
+  }
+
+  return blocks.join("\n\n");
+}
+
+function buildRfpChunkBody(rfp: RfpChunkInput): string {
+  const metadata = asRecord(rfp.metadata);
+  const rawMetadata = asRecord(asRecord(rfp.raw_data).metadata);
+  const combinedMetadata = { ...rawMetadata, ...metadata };
+  const attachmentText = extractedDocumentText(combinedMetadata);
+
+  return [
+    rfp.title?.trim() ? `Title:\n${rfp.title.trim()}` : "",
+    rfp.description?.trim() ? `Description:\n${rfp.description.trim()}` : "",
+    rfp.statement_of_work?.trim()
+      ? `Statement of Work:\n${rfp.statement_of_work.trim()}`
+      : "",
+    rfp.deliverables?.length
+      ? `Deliverables:\n${rfp.deliverables.join("\n")}`
+      : "",
+    attachmentText ? `Extracted Attachment Text:\n${attachmentText}` : "",
+  ]
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+}
 
 /**
- * If the RFP has no vector rows yet, chunk `title` + `description`, embed, and
- * insert into `rfp_chunks` (requires service-role client).
+ * If the RFP has no vector rows yet, chunk the richest RFP text available
+ * (canonical fields plus ingested attachment text), embed, and insert into
+ * `rfp_chunks` (requires service-role client).
  */
 export async function ensureRfpChunksEmbedded(
   admin: AdminClient,
-  rfp: {
-    id: string;
-    title: string | null;
-    description: string | null;
-  },
+  rfp: RfpChunkInput,
 ): Promise<{ created: number }> {
   const { count, error: countErr } = await admin
     .from("rfp_chunks")
@@ -32,10 +94,7 @@ export async function ensureRfpChunksEmbedded(
     return { created: 0 };
   }
 
-  const body = [rfp.title?.trim(), rfp.description?.trim()]
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
+  const body = buildRfpChunkBody(rfp);
 
   const pieces = chunkText(body || "(No description provided for this RFP.)");
   const { embeddings } = await embedMany({
@@ -52,7 +111,7 @@ export async function ensureRfpChunksEmbedded(
     chunk_index,
     chunk_text,
     embedding: embeddings[chunk_index] as unknown as number[],
-    metadata: { source: "description_stub" as const },
+    metadata: { source: "rfp_full_context" as const },
   }));
 
   const { error: insErr } = await admin.from("rfp_chunks").insert(rows);

--- a/web/lib/server/scoring/index.ts
+++ b/web/lib/server/scoring/index.ts
@@ -81,6 +81,10 @@ export async function scoreContractorAgainstRfp(
     id: rfp.id,
     title: rfp.title,
     description: rfp.description,
+    statement_of_work: rfp.statement_of_work,
+    deliverables: rfp.deliverables,
+    metadata: rfp.metadata,
+    raw_data: rfp.raw_data,
   });
   await ensurePastProjectsEmbedded(admin, contractorId);
 

--- a/web/lib/supabase/admin.ts
+++ b/web/lib/supabase/admin.ts
@@ -7,10 +7,11 @@ import type { Database } from "@/lib/database.types";
  */
 export function createServiceRoleClient() {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SECRET_KEY;
   if (!url || !key) {
     throw new Error(
-      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY",
+      "Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY / SUPABASE_SECRET_KEY",
     );
   }
   return createClient<Database>(url, key, {

--- a/web/lib/types.ts
+++ b/web/lib/types.ts
@@ -20,9 +20,8 @@ export type Rfp = {
   /** Placeholder gap analysis for the AI tab */
   aiAnalysisMarkdown: string;
   /**
-   * LLM-generated structured summary (scope of work, deadlines, eval
-   * criteria), formatted as markdown. Null until the user clicks
-   * "Generate summary" or a cached row in `rfp_summaries` is loaded.
+   * Stored structured summary. New rows are JSON encoded `RfpSummary` objects;
+   * legacy rows may be markdown and are rendered as a fallback.
    */
   summaryMarkdown: string | null;
 };


### PR DESCRIPTION
## Changes

- Upgraded RFP summary generation to use full server-side RFP context instead of browser-passed short text.
- Added PDF/DOCX attachment text extraction during ingestion and included extracted text in summary/RAG context.
- Changed “Generate summary” to always regenerate via LLM and save to rfp_summaries.
- Loaded stored summaries by default on dashboard load.
- Expanded structured summary output with specific sections: opportunity posture, technical work areas, contract details, submission guidance, deadlines, evaluation criteria, and contacts.


## Note
We need to add SUPABASE_SECRET_KEY on vercel deployment


<img width="1294" height="798" alt="Screenshot 2026-06-01 at 12 02 28 AM" src="https://github.com/user-attachments/assets/2c9c187b-f98f-4763-a750-74363de4779d" />

