### PR TITLE
feat: added RFP deadline calendar export

### DIFF
--- a/web/components/AddToCalendarButton.tsx
+++ b/web/components/AddToCalendarButton.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useDashboard } from "@/context/DashboardContext";
+import { captureEvent } from "@/lib/analytics";
+import {
+  downloadRfpDeadlineCalendar,
+  hasCalendarDeadline,
+} from "@/lib/calendar";
+import type { Rfp } from "@/lib/types";
+
+function CalendarIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <rect x="3" y="4" width="18" height="17" rx="2" />
+      <path d="M8 2v4M16 2v4M3 10h18" />
+      <path d="m9 15 2 2 4-4" />
+    </svg>
+  );
+}
+
+export function AddToCalendarButton({
+  rfp,
+  compact = false,
+}: {
+  rfp: Rfp;
+  compact?: boolean;
+}) {
+  const { showToast } = useDashboard();
+  const available = hasCalendarDeadline(rfp);
+  const label = available
+    ? "Add deadline to calendar"
+    : "Deadline date unavailable";
+
+  const handleClick = () => {
+    try {
+      downloadRfpDeadlineCalendar(rfp);
+      captureEvent("rfp_deadline_calendar_downloaded", {
+        rfp_id: rfp.id,
+        due_date: rfp.dueDate,
+      });
+      showToast("Calendar file downloaded.");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Could not create calendar file.";
+      showToast(message);
+    }
+  };
+
+  if (compact) {
+    return (
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!available}
+        aria-label={label}
+        title={label}
+        className="flex h-8 w-8 items-center justify-center rounded-lg border border-govbid-border bg-govbid-surface text-govbid-text-muted transition hover:border-govbid-border-strong hover:text-govbid-text disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <CalendarIcon />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={!available}
+      title={label}
+      className="inline-flex items-center gap-2 rounded-lg border border-govbid-border bg-govbid-surface px-3 py-2 text-sm font-medium text-govbid-text transition hover:bg-govbid-primary-muted/40 disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      <CalendarIcon />
+      Add deadline to calendar
+    </button>
+  );
+}

--- a/web/components/DetailPanel.tsx
+++ b/web/components/DetailPanel.tsx
@@ -14,6 +14,7 @@ import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
 import { WALKTHROUGH_SHOW_DETAIL_OVERVIEW_EVENT } from "@/lib/walkthroughEvents";
+import { AddToCalendarButton } from "./AddToCalendarButton";
 
 const RfpPdfViewer = dynamic(
   () => import("./RfpPdfViewer").then((m) => m.RfpPdfViewer),
@@ -307,6 +308,7 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
         >
           {saved ? "Unsave" : "Save to profile"}
         </button>
+        <AddToCalendarButton rfp={rfp} />
         <button
           type="button"
           onClick={handleSummary}

--- a/web/components/DetailPanelVariantB.tsx
+++ b/web/components/DetailPanelVariantB.tsx
@@ -11,6 +11,7 @@ import { SummaryBrief } from "./SummaryBrief";
 import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
+import { AddToCalendarButton } from "./AddToCalendarButton";
 
 const RfpPdfViewer = dynamic(
   () => import("./RfpPdfViewer").then((m) => m.RfpPdfViewer),
@@ -299,6 +300,7 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
                 <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
               </svg>
             </button>
+            <AddToCalendarButton rfp={rfp} compact />
             <button
               type="button"
               onClick={handleSummary}

--- a/web/lib/calendar.ts
+++ b/web/lib/calendar.ts
@@ -1,0 +1,142 @@
+import type { Rfp } from "@/lib/types";
+
+const DATE_ONLY_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+function parseDateOnly(value: string): Date | null {
+  const match = DATE_ONLY_PATTERN.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
+function formatCalendarDate(date: Date): string {
+  return [
+    date.getUTCFullYear(),
+    String(date.getUTCMonth() + 1).padStart(2, "0"),
+    String(date.getUTCDate()).padStart(2, "0"),
+  ].join("");
+}
+
+function formatTimestamp(date: Date): string {
+  return date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "Z");
+}
+
+function escapeCalendarText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/\r?\n/g, "\\n")
+    .replace(/;/g, "\\;")
+    .replace(/,/g, "\\,");
+}
+
+function foldCalendarLine(line: string): string {
+  const encoder = new TextEncoder();
+  const chunks: string[] = [];
+  let current = "";
+
+  for (const character of line) {
+    const byteLimit = chunks.length === 0 ? 75 : 74;
+    if (current && encoder.encode(current + character).length > byteLimit) {
+      chunks.push(current);
+      current = character;
+    } else {
+      current += character;
+    }
+  }
+
+  if (current || chunks.length === 0) {
+    chunks.push(current);
+  }
+
+  return chunks
+    .map((chunk, index) => (index === 0 ? chunk : ` ${chunk}`))
+    .join("\r\n");
+}
+
+function calendarFilename(rfp: Rfp): string {
+  const slug = (rfp.name || rfp.title)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64);
+
+  return `rfp-deadline-${slug || rfp.id}.ics`;
+}
+
+export function hasCalendarDeadline(rfp: Rfp): boolean {
+  return parseDateOnly(rfp.dueDate) !== null;
+}
+
+export function buildRfpDeadlineCalendar(
+  rfp: Rfp,
+  generatedAt = new Date(),
+): string {
+  const startDate = parseDateOnly(rfp.dueDate);
+  if (!startDate) {
+    throw new Error("This RFP does not have a valid deadline date.");
+  }
+
+  const endDate = new Date(startDate);
+  endDate.setUTCDate(endDate.getUTCDate() + 1);
+
+  const description = [
+    `Agency: ${rfp.agency}`,
+    `Contract value: ${rfp.contract}`,
+    "",
+    rfp.description,
+  ]
+    .filter((line, index, lines) => line || lines[index - 1])
+    .join("\n");
+
+  const lines = [
+    "BEGIN:VCALENDAR",
+    "VERSION:2.0",
+    "PRODID:-//GovBid//RFP Deadline Calendar//EN",
+    "CALSCALE:GREGORIAN",
+    "METHOD:PUBLISH",
+    "BEGIN:VEVENT",
+    `UID:${escapeCalendarText(`${rfp.id}-deadline@govbid.app`)}`,
+    `DTSTAMP:${formatTimestamp(generatedAt)}`,
+    `DTSTART;VALUE=DATE:${formatCalendarDate(startDate)}`,
+    `DTEND;VALUE=DATE:${formatCalendarDate(endDate)}`,
+    `SUMMARY:${escapeCalendarText(`RFP deadline: ${rfp.name || rfp.title}`)}`,
+    `DESCRIPTION:${escapeCalendarText(description)}`,
+    `LOCATION:${escapeCalendarText(rfp.location)}`,
+    "STATUS:CONFIRMED",
+    "TRANSP:TRANSPARENT",
+    "END:VEVENT",
+    "END:VCALENDAR",
+  ];
+
+  return `${lines.map(foldCalendarLine).join("\r\n")}\r\n`;
+}
+
+export function downloadRfpDeadlineCalendar(rfp: Rfp): void {
+  const calendar = buildRfpDeadlineCalendar(rfp);
+  const blob = new Blob([calendar], { type: "text/calendar;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+
+  anchor.href = url;
+  anchor.download = calendarFilename(rfp);
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 0);
+}


### PR DESCRIPTION
- Add an “Add deadline to calendar” action to RFP detail views
- Generate and download a standards-compliant `.ics` calendar file
- Include the RFP title, agency, location, contract value, and description
- Disable the action when an RFP has no valid deadline
- Support both dashboard UI variants


Deadlines are exported as all-day events because RFP records currently provide a due date without a verified submission time.