### PR TITLE
feat: add notes and bid status tracking for saved RFPs

### DIFF
--- a/supabase/migrations/20260610114427_saved_rfp_bid_status.sql
+++ b/supabase/migrations/20260610114427_saved_rfp_bid_status.sql
@@ -1,0 +1,21 @@
+-- Track each saved opportunity through the user's bid workflow.
+alter table public.saved_rfps
+  add column if not exists bid_status text;
+
+update public.saved_rfps
+set bid_status = 'reviewing'
+where bid_status is null;
+
+alter table public.saved_rfps
+  alter column bid_status set default 'reviewing',
+  alter column bid_status set not null;
+
+alter table public.saved_rfps
+  drop constraint if exists saved_rfps_bid_status_check;
+
+alter table public.saved_rfps
+  add constraint saved_rfps_bid_status_check
+  check (bid_status in ('reviewing', 'pursuing', 'no_bid', 'submitted'));
+
+comment on column public.saved_rfps.bid_status is
+  'User-managed bid workflow status: reviewing, pursuing, no_bid, or submitted.';

--- a/web/components/DetailPanel.tsx
+++ b/web/components/DetailPanel.tsx
@@ -14,6 +14,7 @@ import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
 import { WALKTHROUGH_SHOW_DETAIL_OVERVIEW_EVENT } from "@/lib/walkthroughEvents";
+import { SavedRfpNotes } from "./SavedRfpNotes";
 
 const RfpPdfViewer = dynamic(
   () => import("./RfpPdfViewer").then((m) => m.RfpPdfViewer),
@@ -82,7 +83,13 @@ export function DetailPanel() {
   return <DetailPanelBody key={selectedRfp.id} rfp={selectedRfp} />;
 }
 
-type DetailTab = "overview" | "document" | "ai" | "summary" | "match";
+type DetailTab =
+  | "overview"
+  | "document"
+  | "ai"
+  | "summary"
+  | "match"
+  | "notes";
 
 const FACTOR_DISPLAY: { key: keyof CompatibilityFactors; label: string; max: number }[] = [
   { key: "timing", label: "Timing", max: 1 },
@@ -264,6 +271,7 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
     { id: "summary", label: "Summary" },
     { id: "ai", label: "AI analysis" },
     { id: "match", label: "Match Details" },
+    { id: "notes", label: "Notes" },
   ];
 
   return (
@@ -275,7 +283,7 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
         id="walkthrough-detail-sidebar"
         className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden"
       >
-        <div className="flex shrink-0 gap-8 border-b border-govbid-border px-4 pt-3 lg:px-5">
+        <div className="flex shrink-0 gap-8 overflow-x-auto border-b border-govbid-border px-4 pt-3 lg:px-5">
         {tabs.map(({ id, label }) => (
           <button
             key={id}
@@ -366,7 +374,7 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
                 ))}
               </div>
             )}
-            
+
             {/* Eligibility Requirements */}
             <div className="rounded-xl border border-govbid-border bg-govbid-elevated p-4">
               <h3 className="text-sm font-semibold text-govbid-text">
@@ -449,6 +457,12 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
             factors={matchFactors}
             scoring={matchScoring}
           />
+        )}
+
+        {tab === "notes" && (
+          <div className="mx-auto w-full max-w-3xl">
+            <SavedRfpNotes rfpId={rfp.id} saved={saved} />
+          </div>
         )}
         </div>
       </div>

--- a/web/components/DetailPanel.tsx
+++ b/web/components/DetailPanel.tsx
@@ -461,7 +461,7 @@ function DetailPanelBody({ rfp }: { rfp: Rfp }) {
 
         {tab === "notes" && (
           <div className="mx-auto w-full max-w-3xl">
-            <SavedRfpNotes rfpId={rfp.id} saved={saved} />
+            <SavedRfpNotes key={rfp.id} rfpId={rfp.id} saved={saved} />
           </div>
         )}
         </div>

--- a/web/components/DetailPanelVariantB.tsx
+++ b/web/components/DetailPanelVariantB.tsx
@@ -466,7 +466,7 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
         )}
 
         {tab === "notes" && (
-          <SavedRfpNotes rfpId={rfp.id} saved={saved} />
+          <SavedRfpNotes key={rfp.id} rfpId={rfp.id} saved={saved} />
         )}
       </div>
     </section>

--- a/web/components/DetailPanelVariantB.tsx
+++ b/web/components/DetailPanelVariantB.tsx
@@ -11,6 +11,7 @@ import { SummaryBrief } from "./SummaryBrief";
 import { TagBubble } from "./RfpCard";
 import { trackABTestEvent } from "@/app/posthog-provider";
 import { shortenAgencyName } from "@/lib/formatAgency";
+import { SavedRfpNotes } from "./SavedRfpNotes";
 
 const RfpPdfViewer = dynamic(
   () => import("./RfpPdfViewer").then((m) => m.RfpPdfViewer),
@@ -71,7 +72,7 @@ export function DetailPanelVariantB() {
   return <DetailPanelBodyB key={selectedRfp.id} rfp={selectedRfp} />;
 }
 
-type DetailTab = "overview" | "document" | "ai" | "summary";
+type DetailTab = "overview" | "document" | "ai" | "summary" | "notes";
 
 function DocumentTabContentB({
   rfp,
@@ -253,6 +254,16 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
         </svg>
       ),
     },
+    {
+      id: "notes",
+      label: "Notes",
+      icon: (
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M4 4h16v16H4z" />
+          <path d="M8 9h8M8 13h8M8 17h5" />
+        </svg>
+      ),
+    },
   ];
 
   return (
@@ -324,7 +335,7 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
         </div>
         
         {/* Pill Tabs */}
-        <div className="flex gap-1">
+        <div className="flex gap-1 overflow-x-auto">
           {tabs.map(({ id, label, icon }) => (
             <button
               key={id}
@@ -452,6 +463,10 @@ function DetailPanelBodyB({ rfp }: { rfp: Rfp }) {
             generating={generating}
             emptyMessage="No stored summary yet. Click the Summary action above to create and save a detailed bidder brief."
           />
+        )}
+
+        {tab === "notes" && (
+          <SavedRfpNotes rfpId={rfp.id} saved={saved} />
         )}
       </div>
     </section>

--- a/web/components/SavedRfpNotes.tsx
+++ b/web/components/SavedRfpNotes.tsx
@@ -2,6 +2,11 @@
 
 import { useState } from "react";
 import { useDashboard } from "@/context/DashboardContext";
+import {
+  DEFAULT_SAVED_RFP_BID_STATUS,
+  SAVED_RFP_BID_STATUSES,
+  type SavedRfpBidStatus,
+} from "@/lib/savedRfpSort";
 
 export function SavedRfpNotes({
   rfpId,
@@ -10,12 +15,22 @@ export function SavedRfpNotes({
   rfpId: string;
   saved: boolean;
 }) {
-  const { savedRfpRecords, updateSavedRfpNotes } = useDashboard();
-  const initialNotes =
-    savedRfpRecords.find((record) => record.rfpId === rfpId)?.notes.trim() ?? "";
+  const {
+    savedRfpRecords,
+    updateSavedRfpBidStatus,
+    updateSavedRfpNotes,
+  } = useDashboard();
+  const savedRecord = savedRfpRecords.find(
+    (record) => record.rfpId === rfpId,
+  );
+  const initialNotes = savedRecord?.notes.trim() ?? "";
+  const bidStatus =
+    savedRecord?.bidStatus ?? DEFAULT_SAVED_RFP_BID_STATUS;
   const [notes, setNotes] = useState(initialNotes);
   const [savedNotes, setSavedNotes] = useState(initialNotes);
   const [saving, setSaving] = useState(false);
+  const [updatingStatus, setUpdatingStatus] =
+    useState<SavedRfpBidStatus | null>(null);
   const changed = notes.trim() !== savedNotes;
 
   const saveNotes = async () => {
@@ -32,61 +47,120 @@ export function SavedRfpNotes({
     }
   };
 
+  const changeBidStatus = async (status: SavedRfpBidStatus) => {
+    if (updatingStatus || status === bidStatus) return;
+    setUpdatingStatus(status);
+    try {
+      await updateSavedRfpBidStatus(rfpId, status);
+    } finally {
+      setUpdatingStatus(null);
+    }
+  };
+
   if (!saved) {
     return (
       <section className="rounded-xl border border-dashed border-govbid-border bg-govbid-elevated/50 p-8 text-center">
         <h2 className="text-base font-semibold text-govbid-text">
-          Save this opportunity to add notes
+          Save this opportunity to track it
         </h2>
         <p className="mt-2 text-sm text-govbid-text-muted">
-          Personal notes are stored with your saved opportunities.
+          Saved opportunities can have a bid status and private notes.
         </p>
       </section>
     );
   }
 
   return (
-    <section className="rounded-xl border border-govbid-border bg-govbid-surface p-4">
-      <div className="flex flex-wrap items-start justify-between gap-2">
+    <section className="overflow-hidden rounded-xl border border-govbid-border bg-govbid-surface">
+      <div className="border-b border-govbid-border p-4">
         <div>
-          <label
-            htmlFor={`saved-rfp-notes-${rfpId}`}
-            className="text-sm font-semibold text-govbid-text"
-          >
-            Personal notes
-          </label>
+          <h2 className="text-sm font-semibold text-govbid-text">Bid status</h2>
           <p className="mt-1 text-xs text-govbid-text-muted">
-            Keep reminders, questions, and follow-up items for this opportunity.
+            Track where this opportunity stands in your response workflow.
           </p>
         </div>
-        {changed && (
-          <span className="text-xs font-medium text-govbid-text-muted">
-            Unsaved changes
-          </span>
-        )}
+
+        <fieldset className="mt-3 grid gap-2 sm:grid-cols-2">
+          <legend className="sr-only">Bid status</legend>
+          {SAVED_RFP_BID_STATUSES.map((option) => {
+            const active = option.value === bidStatus;
+            const pending = option.value === updatingStatus;
+            return (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={active}
+                disabled={updatingStatus != null}
+                onClick={() => void changeBidStatus(option.value)}
+                className={`rounded-lg border p-3 text-left transition ${
+                  active
+                    ? option.activeClassName
+                    : "border-govbid-border bg-govbid-elevated text-govbid-text hover:border-govbid-border-strong"
+                } disabled:cursor-wait disabled:opacity-70`}
+              >
+                <span className="flex items-center justify-between gap-2">
+                  <span className="text-sm font-semibold">{option.label}</span>
+                  <span
+                    className={`size-2.5 rounded-full border ${
+                      active
+                        ? "border-current bg-current"
+                        : "border-govbid-border-strong bg-govbid-surface"
+                    }`}
+                    aria-hidden
+                  />
+                </span>
+                <span className="mt-1 block text-xs opacity-80">
+                  {pending ? "Updating..." : option.description}
+                </span>
+              </button>
+            );
+          })}
+        </fieldset>
       </div>
 
-      <textarea
-        id={`saved-rfp-notes-${rfpId}`}
-        value={notes}
-        onChange={(event) => setNotes(event.target.value)}
-        placeholder="Add a reminder, contact, question, or next step..."
-        rows={4}
-        className="mt-3 w-full resize-y rounded-lg border border-govbid-border bg-govbid-elevated px-3 py-2 text-sm leading-relaxed text-govbid-text outline-none transition placeholder:text-govbid-text-muted focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary"
-      />
+      <div className="p-4">
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <label
+              htmlFor={`saved-rfp-notes-${rfpId}`}
+              className="text-sm font-semibold text-govbid-text"
+            >
+              Personal notes
+            </label>
+            <p className="mt-1 text-xs text-govbid-text-muted">
+              Keep reminders, questions, and follow-up items for this
+              opportunity.
+            </p>
+          </div>
+          {changed && (
+            <span className="text-xs font-medium text-govbid-text-muted">
+              Unsaved changes
+            </span>
+          )}
+        </div>
 
-      <div className="mt-3 flex items-center justify-between gap-3">
-        <p className="text-xs text-govbid-text-muted">
-          Notes are private to your account.
-        </p>
-        <button
-          type="button"
-          onClick={() => void saveNotes()}
-          disabled={!changed || saving}
-          className="govbid-btn-primary rounded-lg px-3 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {saving ? "Saving..." : "Save note"}
-        </button>
+        <textarea
+          id={`saved-rfp-notes-${rfpId}`}
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder="Add a reminder, contact, question, or next step..."
+          rows={5}
+          className="mt-3 w-full resize-y rounded-lg border border-govbid-border bg-govbid-elevated px-3 py-2 text-sm leading-relaxed text-govbid-text outline-none transition placeholder:text-govbid-text-muted focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary"
+        />
+
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <p className="text-xs text-govbid-text-muted">
+            Notes are private to your account.
+          </p>
+          <button
+            type="button"
+            onClick={() => void saveNotes()}
+            disabled={!changed || saving}
+            className="govbid-btn-primary rounded-lg px-3 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {saving ? "Saving..." : "Save note"}
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/web/components/SavedRfpNotes.tsx
+++ b/web/components/SavedRfpNotes.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useDashboard } from "@/context/DashboardContext";
+
+export function SavedRfpNotes({
+  rfpId,
+  saved,
+}: {
+  rfpId: string;
+  saved: boolean;
+}) {
+  const { savedRfpRecords, updateSavedRfpNotes } = useDashboard();
+  const initialNotes =
+    savedRfpRecords.find((record) => record.rfpId === rfpId)?.notes.trim() ?? "";
+  const [notes, setNotes] = useState(initialNotes);
+  const [savedNotes, setSavedNotes] = useState(initialNotes);
+  const [saving, setSaving] = useState(false);
+  const changed = notes.trim() !== savedNotes;
+
+  const saveNotes = async () => {
+    if (saving || !changed) return;
+    const submittedNotes = notes.trim();
+    setSaving(true);
+    try {
+      const saved = await updateSavedRfpNotes(rfpId, submittedNotes);
+      if (saved) {
+        setSavedNotes(submittedNotes);
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!saved) {
+    return (
+      <section className="rounded-xl border border-dashed border-govbid-border bg-govbid-elevated/50 p-8 text-center">
+        <h2 className="text-base font-semibold text-govbid-text">
+          Save this opportunity to add notes
+        </h2>
+        <p className="mt-2 text-sm text-govbid-text-muted">
+          Personal notes are stored with your saved opportunities.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-govbid-border bg-govbid-surface p-4">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <label
+            htmlFor={`saved-rfp-notes-${rfpId}`}
+            className="text-sm font-semibold text-govbid-text"
+          >
+            Personal notes
+          </label>
+          <p className="mt-1 text-xs text-govbid-text-muted">
+            Keep reminders, questions, and follow-up items for this opportunity.
+          </p>
+        </div>
+        {changed && (
+          <span className="text-xs font-medium text-govbid-text-muted">
+            Unsaved changes
+          </span>
+        )}
+      </div>
+
+      <textarea
+        id={`saved-rfp-notes-${rfpId}`}
+        value={notes}
+        onChange={(event) => setNotes(event.target.value)}
+        placeholder="Add a reminder, contact, question, or next step..."
+        rows={4}
+        className="mt-3 w-full resize-y rounded-lg border border-govbid-border bg-govbid-elevated px-3 py-2 text-sm leading-relaxed text-govbid-text outline-none transition placeholder:text-govbid-text-muted focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary"
+      />
+
+      <div className="mt-3 flex items-center justify-between gap-3">
+        <p className="text-xs text-govbid-text-muted">
+          Notes are private to your account.
+        </p>
+        <button
+          type="button"
+          onClick={() => void saveNotes()}
+          disabled={!changed || saving}
+          className="govbid-btn-primary rounded-lg px-3 py-2 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Save note"}
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/web/components/SavedRfpsList.tsx
+++ b/web/components/SavedRfpsList.tsx
@@ -213,6 +213,9 @@ export function SavedRfpsList({
         {displayRfps.map((rfp) => {
           const isCustom = sortMode === "custom";
           const isDragging = draggingId === rfp.id;
+          const notes = savedRfpRecords
+            .find((record) => record.rfpId === rfp.id)
+            ?.notes.trim();
 
           return (
             <li
@@ -261,6 +264,11 @@ export function SavedRfpsList({
                 <span className="mt-1 block text-xs text-govbid-text-muted">
                   {rfp.agency}
                 </span>
+                {notes && (
+                  <span className="mt-2 block line-clamp-2 rounded-md bg-govbid-surface px-2 py-1.5 text-xs leading-relaxed text-govbid-text-muted">
+                    Note: {notes}
+                  </span>
+                )}
                 {showsDueDateSubtitle(sortMode) && (
                   <span className="mt-1 block text-xs text-govbid-text-muted">
                     Due {rfp.dueDate}

--- a/web/components/SavedRfpsList.tsx
+++ b/web/components/SavedRfpsList.tsx
@@ -3,13 +3,17 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { Rfp } from "@/lib/types";
 import {
+  DEFAULT_SAVED_RFP_BID_STATUS,
   formatSavedAtLabel,
+  getSavedRfpBidStatusMeta,
   reorderIdList,
+  SAVED_RFP_BID_STATUSES,
   SAVED_RFP_SORT_MODES,
   showsDueDateSubtitle,
   showsSavedAtSubtitle,
   sortSavedRfps,
   writeSavedRfpSortMode,
+  type SavedRfpBidStatus,
   type SavedRfpRecord,
   type SavedRfpSortMode,
 } from "@/lib/savedRfpSort";
@@ -43,6 +47,8 @@ type Props = {
   onReorder: (orderedIds: string[]) => Promise<void>;
 };
 
+type BidStatusFilter = "all" | SavedRfpBidStatus;
+
 export function SavedRfpsList({
   savedRfps,
   savedRfpRecords,
@@ -51,15 +57,43 @@ export function SavedRfpsList({
   onSelectRfp,
   onReorder,
 }: Props) {
+  const [statusFilter, setStatusFilter] =
+    useState<BidStatusFilter>("all");
+  const recordsById = useMemo(
+    () => new Map(savedRfpRecords.map((record) => [record.rfpId, record])),
+    [savedRfpRecords],
+  );
   const sorted = useMemo(
     () => sortSavedRfps(savedRfps, savedRfpRecords, sortMode),
     [savedRfps, savedRfpRecords, sortMode],
   );
+  const filteredSorted = useMemo(
+    () =>
+      statusFilter === "all"
+        ? sorted
+        : sorted.filter(
+            (rfp) =>
+              (recordsById.get(rfp.id)?.bidStatus ??
+                DEFAULT_SAVED_RFP_BID_STATUS) === statusFilter,
+          ),
+    [recordsById, sorted, statusFilter],
+  );
+  const statusCounts = useMemo(() => {
+    const counts = new Map<SavedRfpBidStatus, number>();
+    for (const record of savedRfpRecords) {
+      counts.set(record.bidStatus, (counts.get(record.bidStatus) ?? 0) + 1);
+    }
+    return counts;
+  }, [savedRfpRecords]);
 
-  const sortedIds = useMemo(() => sorted.map((r) => r.id), [sorted]);
+  const sortedIds = useMemo(
+    () => filteredSorted.map((r) => r.id),
+    [filteredSorted],
+  );
+  const sortedIdsKey = sortedIds.join("|");
   const sortedById = useMemo(
-    () => new Map(sorted.map((r) => [r.id, r])),
-    [sorted],
+    () => new Map(filteredSorted.map((r) => [r.id, r])),
+    [filteredSorted],
   );
 
   const [draftIds, setDraftIds] = useState<string[] | null>(null);
@@ -82,11 +116,16 @@ export function SavedRfpsList({
     if (!draggingId) {
       setDraftIds(null);
     }
-  }, [sortedIds.join("|"), draggingId]);
+  }, [sortedIdsKey, draggingId]);
 
   const handleSortChange = (mode: SavedRfpSortMode) => {
     writeSavedRfpSortMode(mode);
     onSortModeChange(mode);
+    setDraftIds(null);
+  };
+
+  const handleStatusFilterChange = (filter: BidStatusFilter) => {
+    setStatusFilter(filter);
     setDraftIds(null);
   };
 
@@ -131,7 +170,7 @@ export function SavedRfpsList({
     e: React.PointerEvent<HTMLButtonElement>,
     rfpId: string,
   ) => {
-    if (sortMode !== "custom" || savingOrder) return;
+    if (sortMode !== "custom" || statusFilter !== "all" || savingOrder) return;
     e.preventDefault();
     e.stopPropagation();
     e.currentTarget.setPointerCapture(e.pointerId);
@@ -185,110 +224,162 @@ export function SavedRfpsList({
 
   return (
     <div className="space-y-3">
-      <label className="flex flex-col gap-1.5">
-        <span className="text-xs font-medium text-govbid-text-muted">Sort by</span>
-        <select
-          value={sortMode}
-          onChange={(e) => handleSortChange(e.target.value as SavedRfpSortMode)}
-          disabled={savingOrder || draggingId != null}
-          className="w-full rounded-lg border border-govbid-border bg-govbid-surface px-3 py-2 text-sm text-govbid-text outline-none focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary disabled:opacity-60"
-          aria-label="Sort saved opportunities"
-        >
-          {SAVED_RFP_SORT_MODES.map(({ value, label }) => (
-            <option key={value} value={value}>
-              {label}
-            </option>
-          ))}
-        </select>
-      </label>
+      <div className="grid gap-2 sm:grid-cols-2">
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-govbid-text-muted">
+            Sort by
+          </span>
+          <select
+            value={sortMode}
+            onChange={(e) =>
+              handleSortChange(e.target.value as SavedRfpSortMode)
+            }
+            disabled={savingOrder || draggingId != null}
+            className="w-full rounded-lg border border-govbid-border bg-govbid-surface px-3 py-2 text-sm text-govbid-text outline-none focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary disabled:opacity-60"
+            aria-label="Sort saved opportunities"
+          >
+            {SAVED_RFP_SORT_MODES.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium text-govbid-text-muted">
+            Bid status
+          </span>
+          <select
+            value={statusFilter}
+            onChange={(event) =>
+              handleStatusFilterChange(event.target.value as BidStatusFilter)
+            }
+            disabled={savingOrder || draggingId != null}
+            className="w-full rounded-lg border border-govbid-border bg-govbid-surface px-3 py-2 text-sm text-govbid-text outline-none focus:border-govbid-primary focus:outline focus:outline-2 focus:outline-offset-0 focus:outline-govbid-primary disabled:opacity-60"
+            aria-label="Filter saved opportunities by bid status"
+          >
+            <option value="all">All statuses ({savedRfps.length})</option>
+            {SAVED_RFP_BID_STATUSES.map(({ value, label }) => (
+              <option key={value} value={value}>
+                {label} ({statusCounts.get(value) ?? 0})
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
 
       {sortMode === "custom" && (
         <p className="text-xs text-govbid-text-muted">
-          Drag opportunities to reorder.{" "}
-          {savingOrder ? "Saving order…" : "Order is saved to your profile."}
+          {statusFilter === "all"
+            ? "Drag opportunities to reorder. "
+            : "Choose All statuses to edit your custom order. "}
+          {statusFilter === "all" &&
+            (savingOrder
+              ? "Saving order..."
+              : "Order is saved to your profile.")}
         </p>
       )}
 
-      <ul className="grid gap-2">
-        {displayRfps.map((rfp) => {
-          const isCustom = sortMode === "custom";
-          const isDragging = draggingId === rfp.id;
-          const notes = savedRfpRecords
-            .find((record) => record.rfpId === rfp.id)
-            ?.notes.trim();
+      {displayRfps.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-govbid-border bg-govbid-elevated/50 p-5 text-center">
+          <p className="text-sm font-medium text-govbid-text">
+            No opportunities with this status
+          </p>
+          <p className="mt-1 text-xs text-govbid-text-muted">
+            Change an opportunity&apos;s status from its Notes tab.
+          </p>
+        </div>
+      ) : (
+        <ul className="grid gap-2">
+          {displayRfps.map((rfp) => {
+            const isCustom = sortMode === "custom" && statusFilter === "all";
+            const isDragging = draggingId === rfp.id;
+            const record = recordsById.get(rfp.id);
+            const notes = record?.notes.trim();
+            const bidStatus =
+              record?.bidStatus ?? DEFAULT_SAVED_RFP_BID_STATUS;
+            const statusMeta = getSavedRfpBidStatusMeta(bidStatus);
 
-          return (
-            <li
-              key={rfp.id}
-              data-rfp-id={rfp.id}
-              className={`flex items-stretch gap-1 rounded-lg transition-shadow ${
-                isDragging ? "relative z-10 shadow-md" : ""
-              }`}
-            >
-              {isCustom && (
-                <button
-                  type="button"
-                  onPointerDown={(e) => handleGripPointerDown(e, rfp.id)}
-                  onPointerMove={handleGripPointerMove}
-                  onPointerUp={handleGripPointerUp}
-                  onPointerCancel={handleGripPointerCancel}
-                  disabled={savingOrder}
-                  className={`flex shrink-0 touch-none items-center rounded-l-lg border border-r-0 border-govbid-border bg-govbid-elevated px-2 select-none ${
-                    savingOrder
-                      ? "cursor-not-allowed opacity-50"
-                      : "cursor-grab active:cursor-grabbing"
-                  }`}
-                  aria-label={`Reorder ${rfp.title}`}
-                  title="Drag to reorder"
-                >
-                  <GripIcon />
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => {
-                  if (draggingId) return;
-                  onSelectRfp(rfp.id);
-                }}
-                className={`saved-rfp-item min-w-0 flex-1 border bg-govbid-elevated p-3 text-left text-sm transition hover:border-govbid-primary/40 hover:bg-govbid-primary-muted/30 ${
-                  isCustom ? "rounded-r-lg rounded-l-none" : "rounded-lg"
-                } ${
-                  isDragging
-                    ? "border-govbid-primary/50 bg-govbid-primary-muted/20"
-                    : "border-govbid-border"
+            return (
+              <li
+                key={rfp.id}
+                data-rfp-id={rfp.id}
+                className={`flex items-stretch gap-1 rounded-lg transition-shadow ${
+                  isDragging ? "relative z-10 shadow-md" : ""
                 }`}
               >
-                <span className="line-clamp-2 font-semibold text-govbid-text">
-                  {rfp.title}
-                </span>
-                <span className="mt-1 block text-xs text-govbid-text-muted">
-                  {rfp.agency}
-                </span>
-                {notes && (
-                  <span className="mt-2 block line-clamp-2 rounded-md bg-govbid-surface px-2 py-1.5 text-xs leading-relaxed text-govbid-text-muted">
-                    Note: {notes}
-                  </span>
+                {isCustom && (
+                  <button
+                    type="button"
+                    onPointerDown={(e) => handleGripPointerDown(e, rfp.id)}
+                    onPointerMove={handleGripPointerMove}
+                    onPointerUp={handleGripPointerUp}
+                    onPointerCancel={handleGripPointerCancel}
+                    disabled={savingOrder}
+                    className={`flex shrink-0 touch-none items-center rounded-l-lg border border-r-0 border-govbid-border bg-govbid-elevated px-2 select-none ${
+                      savingOrder
+                        ? "cursor-not-allowed opacity-50"
+                        : "cursor-grab active:cursor-grabbing"
+                    }`}
+                    aria-label={`Reorder ${rfp.title}`}
+                    title="Drag to reorder"
+                  >
+                    <GripIcon />
+                  </button>
                 )}
-                {showsDueDateSubtitle(sortMode) && (
-                  <span className="mt-1 block text-xs text-govbid-text-muted">
-                    Due {rfp.dueDate}
-                  </span>
-                )}
-                {showsSavedAtSubtitle(sortMode) && (() => {
-                  const savedLabel = formatSavedAtLabel(
-                    savedRfpRecords.find((r) => r.rfpId === rfp.id)?.savedAt,
-                  );
-                  return savedLabel ? (
-                    <span className="mt-1 block text-xs text-govbid-text-muted">
-                      Saved {savedLabel}
+                <button
+                  type="button"
+                  onClick={() => {
+                    if (draggingId) return;
+                    onSelectRfp(rfp.id);
+                  }}
+                  className={`saved-rfp-item min-w-0 flex-1 border bg-govbid-elevated p-3 text-left text-sm transition hover:border-govbid-primary/40 hover:bg-govbid-primary-muted/30 ${
+                    isCustom ? "rounded-r-lg rounded-l-none" : "rounded-lg"
+                  } ${
+                    isDragging
+                      ? "border-govbid-primary/50 bg-govbid-primary-muted/20"
+                      : "border-govbid-border"
+                  }`}
+                >
+                  <span className="flex items-start justify-between gap-2">
+                    <span className="line-clamp-2 font-semibold text-govbid-text">
+                      {rfp.title}
                     </span>
-                  ) : null;
-                })()}
-              </button>
-            </li>
-          );
-        })}
-      </ul>
+                    <span
+                      className={`shrink-0 rounded-full border px-2 py-0.5 text-[10px] font-semibold ${statusMeta.badgeClassName}`}
+                    >
+                      {statusMeta.label}
+                    </span>
+                  </span>
+                  <span className="mt-1 block text-xs text-govbid-text-muted">
+                    {rfp.agency}
+                  </span>
+                  {notes && (
+                    <span className="mt-2 block line-clamp-2 rounded-md bg-govbid-surface px-2 py-1.5 text-xs leading-relaxed text-govbid-text-muted">
+                      Note: {notes}
+                    </span>
+                  )}
+                  {showsDueDateSubtitle(sortMode) && (
+                    <span className="mt-1 block text-xs text-govbid-text-muted">
+                      Due {rfp.dueDate}
+                    </span>
+                  )}
+                  {showsSavedAtSubtitle(sortMode) &&
+                    (() => {
+                      const savedLabel = formatSavedAtLabel(record?.savedAt);
+                      return savedLabel ? (
+                        <span className="mt-1 block text-xs text-govbid-text-muted">
+                          Saved {savedLabel}
+                        </span>
+                      ) : null;
+                    })()}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </div>
   );
 }

--- a/web/context/DashboardContext.tsx
+++ b/web/context/DashboardContext.tsx
@@ -36,7 +36,10 @@ import {
 } from "@/lib/rfpSummary";
 import {
   buildSavedRfpRecordsInOrder,
+  DEFAULT_SAVED_RFP_BID_STATUS,
+  getSavedRfpBidStatusMeta,
   nextSortPosition,
+  type SavedRfpBidStatus,
   type SavedRfpRecord,
 } from "@/lib/savedRfpSort";
 
@@ -81,6 +84,10 @@ type DashboardContextValue = {
   isSaved: (id: string) => boolean;
   toggleSaveRfp: (id: string) => Promise<void>;
   updateSavedRfpNotes: (id: string, notes: string) => Promise<boolean>;
+  updateSavedRfpBidStatus: (
+    id: string,
+    status: SavedRfpBidStatus,
+  ) => Promise<boolean>;
   /** Persist custom drag order (profile sort = custom). */
   reorderSavedRfps: (orderedIds: string[]) => Promise<void>;
   profile: ContractorProfile;
@@ -265,7 +272,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
         const { data: savedRows } = await supabase
           .from("saved_rfps")
-          .select("rfp_id, saved_at, sort_position, notes")
+          .select("rfp_id, saved_at, sort_position, notes, bid_status")
           .eq("contractor_id", cid)
           .order("sort_position", { ascending: true, nullsFirst: false })
           .order("saved_at", { ascending: true });
@@ -275,6 +282,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             savedAt: r.saved_at,
             sortPosition: r.sort_position,
             notes: r.notes ?? "",
+            bidStatus: r.bid_status ?? DEFAULT_SAVED_RFP_BID_STATUS,
           })),
         );
 
@@ -382,15 +390,29 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     const supabase = createClient();
 
     const init = async () => {
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (user) {
-        await loadWorkspace(user.id, user.email ?? undefined);
-      } else {
+      try {
+        const {
+          data: { user },
+          error,
+        } = await supabase.auth.getUser();
+        if (error) throw error;
+
+        if (user) {
+          await loadWorkspace(user.id, user.email ?? undefined);
+        } else {
+          clearWorkspace();
+        }
+      } catch (error) {
+        console.error("Dashboard authentication failed:", error);
         clearWorkspace();
+        showToast(
+          error instanceof Error
+            ? error.message
+            : "Could not load your account. Please refresh and try again.",
+        );
+      } finally {
+        startTransition(() => setAuthReady(true));
       }
-      startTransition(() => setAuthReady(true));
     };
 
     void init();
@@ -400,21 +422,32 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     } = supabase.auth.onAuthStateChange((_event, session) => {
       startTransition(() => {
         void (async () => {
-          if (session?.user) {
-            await loadWorkspace(
-              session.user.id,
-              session.user.email ?? undefined,
-            );
-          } else {
+          try {
+            if (session?.user) {
+              await loadWorkspace(
+                session.user.id,
+                session.user.email ?? undefined,
+              );
+            } else {
+              clearWorkspace();
+            }
+          } catch (error) {
+            console.error("Dashboard auth state update failed:", error);
             clearWorkspace();
+            showToast(
+              error instanceof Error
+                ? error.message
+                : "Could not refresh your account.",
+            );
+          } finally {
+            setAuthReady(true);
           }
-          setAuthReady(true);
         })();
       });
     });
 
     return () => subscription.unsubscribe();
-  }, [loadWorkspace, clearWorkspace]);
+  }, [loadWorkspace, clearWorkspace, showToast]);
 
   const savedRfpIds = useMemo(
     () => savedRfpRecords.map((r) => r.rfpId),
@@ -659,7 +692,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             rfp_id: id,
             sort_position: sortPosition,
           })
-          .select("rfp_id, saved_at, sort_position, notes")
+          .select("rfp_id, saved_at, sort_position, notes, bid_status")
           .single();
         if (error) {
           showToast(error.message);
@@ -673,6 +706,8 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               savedAt: inserted.saved_at,
               sortPosition: inserted.sort_position,
               notes: inserted.notes ?? "",
+              bidStatus:
+                inserted.bid_status ?? DEFAULT_SAVED_RFP_BID_STATUS,
             },
           ]);
         }
@@ -724,6 +759,50 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         has_notes: normalizedNotes.length > 0,
       });
       showToast(normalizedNotes ? "Note saved." : "Note removed.");
+      return true;
+    },
+    [contractorId, savedRfpIds, showToast],
+  );
+
+  const updateSavedRfpBidStatus = useCallback(
+    async (id: string, status: SavedRfpBidStatus) => {
+      if (!contractorId) {
+        showToast("Profile not ready yet.");
+        return false;
+      }
+      if (!savedRfpIds.includes(id)) {
+        showToast("Save this opportunity before changing its bid status.");
+        return false;
+      }
+
+      const supabase = createClient();
+      const { data: updated, error } = await supabase
+        .from("saved_rfps")
+        .update({ bid_status: status })
+        .eq("contractor_id", contractorId)
+        .eq("rfp_id", id)
+        .select("rfp_id")
+        .maybeSingle();
+
+      if (error) {
+        showToast(error.message);
+        return false;
+      }
+      if (!updated) {
+        showToast("This opportunity is no longer saved.");
+        return false;
+      }
+
+      setSavedRfpRecords((prev) =>
+        prev.map((record) =>
+          record.rfpId === id ? { ...record, bidStatus: status } : record,
+        ),
+      );
+      captureEvent("saved_rfp_bid_status_updated", {
+        rfp_id: id,
+        bid_status: status,
+      });
+      showToast(`Bid status changed to ${getSavedRfpBidStatusMeta(status).label}.`);
       return true;
     },
     [contractorId, savedRfpIds, showToast],
@@ -989,6 +1068,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       isSaved,
       toggleSaveRfp,
       updateSavedRfpNotes,
+      updateSavedRfpBidStatus,
       reorderSavedRfps,
       profile,
       setProfile,
@@ -1032,6 +1112,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       isSaved,
       toggleSaveRfp,
       updateSavedRfpNotes,
+      updateSavedRfpBidStatus,
       reorderSavedRfps,
       profile,
       setProfile,

--- a/web/context/DashboardContext.tsx
+++ b/web/context/DashboardContext.tsx
@@ -80,6 +80,7 @@ type DashboardContextValue = {
   savedRfpRecords: SavedRfpRecord[];
   isSaved: (id: string) => boolean;
   toggleSaveRfp: (id: string) => Promise<void>;
+  updateSavedRfpNotes: (id: string, notes: string) => Promise<boolean>;
   /** Persist custom drag order (profile sort = custom). */
   reorderSavedRfps: (orderedIds: string[]) => Promise<void>;
   profile: ContractorProfile;
@@ -264,7 +265,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
         const { data: savedRows } = await supabase
           .from("saved_rfps")
-          .select("rfp_id, saved_at, sort_position")
+          .select("rfp_id, saved_at, sort_position, notes")
           .eq("contractor_id", cid)
           .order("sort_position", { ascending: true, nullsFirst: false })
           .order("saved_at", { ascending: true });
@@ -273,6 +274,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             rfpId: r.rfp_id,
             savedAt: r.saved_at,
             sortPosition: r.sort_position,
+            notes: r.notes ?? "",
           })),
         );
 
@@ -657,7 +659,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
             rfp_id: id,
             sort_position: sortPosition,
           })
-          .select("rfp_id, saved_at, sort_position")
+          .select("rfp_id, saved_at, sort_position, notes")
           .single();
         if (error) {
           showToast(error.message);
@@ -670,6 +672,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
               rfpId: inserted.rfp_id,
               savedAt: inserted.saved_at,
               sortPosition: inserted.sort_position,
+              notes: inserted.notes ?? "",
             },
           ]);
         }
@@ -677,6 +680,53 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       }
     },
     [contractorId, savedRfpIds, savedRfpRecords, showToast],
+  );
+
+  const updateSavedRfpNotes = useCallback(
+    async (id: string, notes: string) => {
+      if (!contractorId) {
+        showToast("Profile not ready yet.");
+        return false;
+      }
+      if (!savedRfpIds.includes(id)) {
+        showToast("Save this opportunity before adding notes.");
+        return false;
+      }
+
+      const normalizedNotes = notes.trim();
+      const supabase = createClient();
+      const { data: updated, error } = await supabase
+        .from("saved_rfps")
+        .update({ notes: normalizedNotes || null })
+        .eq("contractor_id", contractorId)
+        .eq("rfp_id", id)
+        .select("rfp_id")
+        .maybeSingle();
+
+      if (error) {
+        showToast(error.message);
+        return false;
+      }
+      if (!updated) {
+        showToast("This opportunity is no longer saved.");
+        return false;
+      }
+
+      setSavedRfpRecords((prev) =>
+        prev.map((record) =>
+          record.rfpId === id
+            ? { ...record, notes: normalizedNotes }
+            : record,
+        ),
+      );
+      captureEvent("saved_rfp_notes_updated", {
+        rfp_id: id,
+        has_notes: normalizedNotes.length > 0,
+      });
+      showToast(normalizedNotes ? "Note saved." : "Note removed.");
+      return true;
+    },
+    [contractorId, savedRfpIds, showToast],
   );
 
   const reorderSavedRfps = useCallback(
@@ -938,6 +988,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       savedRfpRecords,
       isSaved,
       toggleSaveRfp,
+      updateSavedRfpNotes,
       reorderSavedRfps,
       profile,
       setProfile,
@@ -980,6 +1031,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       savedRfpRecords,
       isSaved,
       toggleSaveRfp,
+      updateSavedRfpNotes,
       reorderSavedRfps,
       profile,
       setProfile,

--- a/web/lib/database.types.ts
+++ b/web/lib/database.types.ts
@@ -269,6 +269,7 @@ export interface Database {
 
       saved_rfps: {
         Row: {
+          bid_status: 'reviewing' | 'pursuing' | 'no_bid' | 'submitted'
           contractor_id: string
           rfp_id: string
           notes: string | null
@@ -276,6 +277,7 @@ export interface Database {
           sort_position: number | null
         }
         Insert: {
+          bid_status?: 'reviewing' | 'pursuing' | 'no_bid' | 'submitted'
           contractor_id: string
           rfp_id: string
           notes?: string | null

--- a/web/lib/savedRfpSort.ts
+++ b/web/lib/savedRfpSort.ts
@@ -1,10 +1,67 @@
 import type { Rfp } from "@/lib/types";
 
+export type SavedRfpBidStatus =
+  | "reviewing"
+  | "pursuing"
+  | "no_bid"
+  | "submitted";
+
+export const DEFAULT_SAVED_RFP_BID_STATUS: SavedRfpBidStatus = "reviewing";
+
+export const SAVED_RFP_BID_STATUSES: {
+  value: SavedRfpBidStatus;
+  label: string;
+  description: string;
+  badgeClassName: string;
+  activeClassName: string;
+}[] = [
+  {
+    value: "reviewing",
+    label: "Reviewing",
+    description: "Evaluating fit and requirements",
+    badgeClassName: "border-blue-200 bg-blue-50 text-blue-700",
+    activeClassName: "border-blue-400 bg-blue-50 text-blue-800",
+  },
+  {
+    value: "pursuing",
+    label: "Pursuing",
+    description: "Preparing a response",
+    badgeClassName:
+      "border-govbid-primary/30 bg-govbid-primary-muted text-govbid-primary",
+    activeClassName:
+      "border-govbid-primary bg-govbid-primary-muted text-govbid-primary",
+  },
+  {
+    value: "no_bid",
+    label: "No Bid",
+    description: "Decided not to respond",
+    badgeClassName:
+      "border-govbid-border bg-govbid-elevated text-govbid-text-muted",
+    activeClassName:
+      "border-govbid-border-strong bg-govbid-elevated text-govbid-text",
+  },
+  {
+    value: "submitted",
+    label: "Submitted",
+    description: "Response delivered",
+    badgeClassName: "border-green-200 bg-green-50 text-green-700",
+    activeClassName: "border-green-400 bg-green-50 text-green-800",
+  },
+];
+
+export function getSavedRfpBidStatusMeta(status: SavedRfpBidStatus) {
+  return (
+    SAVED_RFP_BID_STATUSES.find((option) => option.value === status) ??
+    SAVED_RFP_BID_STATUSES[0]
+  );
+}
+
 export type SavedRfpRecord = {
   rfpId: string;
   savedAt: string;
   sortPosition: number | null;
   notes: string;
+  bidStatus: SavedRfpBidStatus;
 };
 
 export type SavedRfpSortMode =

--- a/web/lib/savedRfpSort.ts
+++ b/web/lib/savedRfpSort.ts
@@ -4,6 +4,7 @@ export type SavedRfpRecord = {
   rfpId: string;
   savedAt: string;
   sortPosition: number | null;
+  notes: string;
 };
 
 export type SavedRfpSortMode =


### PR DESCRIPTION
## Changes

- Add personal notes to saved RFPs
- Add bid statuses: Reviewing, Pursuing, No Bid, and Submitted
- Display status badges on saved RFP cards
- Add filtering by bid status
- Persist notes and status in Supabase
- Prevent authentication errors from leaving the dashboard stuck loading

## Database Changes

Adds a `bid_status` column to `saved_rfps`, defaulting to `reviewing`.

<img width="1456" height="904" alt="Screenshot 2026-06-10 at 4 56 13 AM" src="https://github.com/user-attachments/assets/a065b467-d28d-49c0-b307-18119a46bc65" />



