### PR TITLE
feat: pre-generate RFP summaries via backfill script

### DIFF
--- a/web/app/api/summary/route.ts
+++ b/web/app/api/summary/route.ts
@@ -1,236 +1,14 @@
 import type { NextRequest } from "next/server";
-import OpenAI from "openai";
-import { zodTextFormat } from "openai/helpers/zod";
 
-import type { Database, Json } from "@/lib/database.types";
+import { SummaryRequestSchema } from "@/lib/rfpSummary";
 import {
-  DETAILED_SUMMARY_PROMPT_VERSION,
-  GENERAL_SUMMARY_TYPE,
-  RfpSummarySchema,
-  SummaryRequestSchema,
-} from "@/lib/rfpSummary";
+  deleteStaleSummaries,
+  generateSummary,
+  loadRfpContext,
+  storeSummary,
+} from "@/lib/server/summaryGenerate";
 import { createServiceRoleClient } from "@/lib/supabase/admin";
 import { createClient } from "@/lib/supabase/server";
-
-const SYSTEM_INSTRUCTIONS = [
-  "You summarize US government RFPs (Requests for Proposal) for prospective contractors.",
-  "Only use facts that are explicitly present in the provided RFP database record, extracted attachment text, or indexed RFP chunks.",
-  "Do not speculate, infer, or pull information from outside the provided material.",
-  "If a field is not stated in the provided material, return 'unknown' for strings or an empty array for lists.",
-  "Canonical database fields are source material too; if a canonical line says 'Due date: ...' or 'Contact email: ...', you may cite that exact line.",
-  "Every deadline, evaluation criterion, contract detail, technical work area, submission instruction, contact, and opportunity-posture claim must include a verbatim citation quote copied from the provided material.",
-  "Actively look for opportunity posture signals: RFI, sources sought, market research, presolicitation, notice of intent, sole source, intended awardee, incumbent, follow-on, recompete, set-aside, and competition caveats.",
-  "Actively look for contract mechanics: solicitation number, notice type, NAICS, PSC, set-aside, contract type, pricing, period of performance, option periods, extension periods, place of performance, agency office, size standard, authority, and intended awardee.",
-  "Actively look for technical work areas: named systems, platforms, software/toolsets, maintenance/sustainment tasks, modernization/migration tasks, security requirements, clearances, support volumes, SLAs, ticketing tools, audit logging, role-based security, patching, upgrades, and deliverables.",
-  "Actively look for submission guidance: what vendors should submit, deadline, email/portal, page limits, format, whether submissions will only inform market research or a competition decision, and whether the government will pay for responses.",
-].join(" ");
-
-const MAX_CONTEXT_CHARS = 200_000;
-const MAX_SECTION_CHARS = 80_000;
-const PDF_URL_KEYS = [
-  "pdf_url_1",
-  "pdf_url_2",
-  "pdf_url_3",
-  "pdf_url_4",
-  "pdf_url_5",
-  "pdf_url_6",
-  "pdf_url_7",
-  "pdf_url_8",
-  "pdf_url_9",
-  "pdf_url_10",
-] as const;
-
-type RfpRow = Database["public"]["Tables"]["rfps"]["Row"];
-type RfpChunkRow = Pick<
-  Database["public"]["Tables"]["rfp_chunks"]["Row"],
-  "chunk_index" | "chunk_text" | "metadata"
->;
-
-function asRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : {};
-}
-
-function asArray(value: unknown): unknown[] {
-  return Array.isArray(value) ? value : [];
-}
-
-function cleanString(value: unknown): string {
-  return typeof value === "string" ? value.trim() : "";
-}
-
-function displayValue(value: unknown): string {
-  if (value == null) return "";
-  if (typeof value === "string") return value.trim();
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  if (Array.isArray(value)) {
-    return value
-      .map((item) => displayValue(item))
-      .filter(Boolean)
-      .join(", ");
-  }
-  const record = asRecord(value);
-  if (Object.keys(record).length === 0) return "";
-  return JSON.stringify(record);
-}
-
-function line(label: string, value: unknown): string | null {
-  const text = displayValue(value);
-  return text ? `${label}: ${text}` : null;
-}
-
-function pushSection(parts: string[], title: string, body: string): void {
-  const trimmed = body.trim();
-  if (!trimmed) return;
-  parts.push(`## ${title}\n${trimmed.slice(0, MAX_SECTION_CHARS)}`);
-}
-
-function compactJson(value: unknown): string {
-  if (value == null) return "";
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return "";
-  }
-}
-
-function withoutLargeTextFields(record: Record<string, unknown>) {
-  const out: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(record)) {
-    if (
-      key === "documents" ||
-      key === "extracted_document_text" ||
-      key === "extracted_document_texts"
-    ) {
-      continue;
-    }
-    out[key] = value;
-  }
-  return out;
-}
-
-function documentLines(metadata: Record<string, unknown>, row: RfpRow): string {
-  const lines: string[] = [];
-  const docs = asArray(metadata.documents);
-  docs.forEach((value, index) => {
-    const doc = asRecord(value);
-    const fields = [
-      line("label", doc.label),
-      line("type", doc.type),
-      line("description", doc.attachment_description),
-      line("source_url", doc.source_url),
-      line("drive_url", doc.url),
-      line("size_bytes", doc.size_bytes),
-    ].filter((item): item is string => Boolean(item));
-    if (fields.length) {
-      lines.push(`Document ${index + 1}: ${fields.join("; ")}`);
-    }
-  });
-
-  PDF_URL_KEYS.forEach((key) => {
-    const url = row[key];
-    if (typeof url === "string" && url.trim()) {
-      lines.push(`${key}: ${url.trim()}`);
-    }
-  });
-
-  return Array.from(new Set(lines)).join("\n");
-}
-
-function extractedDocumentText(metadata: Record<string, unknown>): string {
-  const blocks: string[] = [];
-  for (const value of asArray(metadata.extracted_document_texts)) {
-    const entry = asRecord(value);
-    const text = cleanString(entry.text);
-    if (!text) continue;
-    const label = cleanString(entry.label) || "Attached document";
-    const type = cleanString(entry.type);
-    blocks.push(
-      [`### ${label}${type ? ` (${type})` : ""}`, text].join("\n"),
-    );
-  }
-
-  const singleText = cleanString(metadata.extracted_document_text);
-  if (singleText && !blocks.some((block) => block.includes(singleText.slice(0, 100)))) {
-    blocks.push(`### Extracted attachment text\n${singleText}`);
-  }
-
-  return blocks.join("\n\n---\n\n");
-}
-
-function buildRfpContext(row: RfpRow, chunks: RfpChunkRow[]): string {
-  const metadata = asRecord(row.metadata as Json | null);
-  const rawData = asRecord(row.raw_data as Json | null);
-  const rawMetadata = asRecord(rawData.metadata);
-  const combinedMetadata = { ...rawMetadata, ...metadata };
-  const parts: string[] = [];
-
-  pushSection(
-    parts,
-    "Canonical RFP Fields",
-    [
-      line("Source", row.source),
-      line("External ID", row.external_id),
-      line("Title", row.title),
-      line("Short name", row.name),
-      line("Department / agency", row.department),
-      line("Status", row.status),
-      line("Posted date", row.posted_date),
-      line("Due date", row.due_date),
-      line("Location", row.location),
-      line("State", row.state),
-      line("Location level", row.location_level),
-      line("Contract amount minimum", row.contract_amount_min),
-      line("Contract amount maximum", row.contract_amount_max),
-      line("Tags", row.tags),
-      line("Contact name", row.contact_name),
-      line("Contact email", row.contact_email),
-      line("Contact phone", row.contact_phone),
-    ]
-      .filter((item): item is string => Boolean(item))
-      .join("\n"),
-  );
-
-  pushSection(parts, "Description", row.description ?? "");
-  pushSection(parts, "Statement of Work", row.statement_of_work ?? "");
-  pushSection(parts, "Deliverables", (row.deliverables ?? []).join("\n"));
-  pushSection(parts, "Attached Documents", documentLines(combinedMetadata, row));
-  pushSection(
-    parts,
-    "Source Metadata",
-    compactJson(withoutLargeTextFields(combinedMetadata)),
-  );
-  pushSection(
-    parts,
-    "Extracted Attachment Text",
-    extractedDocumentText(combinedMetadata),
-  );
-
-  if (chunks.length > 0) {
-    pushSection(
-      parts,
-      "Indexed RFP Chunks",
-      chunks
-        .sort((a, b) => a.chunk_index - b.chunk_index)
-        .map((chunk) => {
-          const meta = compactJson(chunk.metadata);
-          return [
-            `### Chunk ${chunk.chunk_index}`,
-            meta ? `Metadata: ${meta}` : "",
-            chunk.chunk_text,
-          ]
-            .filter(Boolean)
-            .join("\n");
-        })
-        .join("\n\n---\n\n"),
-    );
-  }
-
-  return parts.join("\n\n").slice(0, MAX_CONTEXT_CHARS);
-}
 
 export async function POST(request: NextRequest) {
   let rawBody: unknown;
@@ -289,47 +67,21 @@ export async function POST(request: NextRequest) {
         { status: 503 },
       );
     }
-    const dataClient = admin;
     cacheTarget = { rfpId, admin };
 
-    await admin
-      .from("rfp_summaries")
-      .delete()
-      .eq("rfp_id", rfpId)
-      .eq("summary_type", GENERAL_SUMMARY_TYPE)
-      .is("prompt_version", null);
-    await admin
-      .from("rfp_summaries")
-      .delete()
-      .eq("rfp_id", rfpId)
-      .eq("summary_type", GENERAL_SUMMARY_TYPE)
-      .neq("prompt_version", DETAILED_SUMMARY_PROMPT_VERSION);
+    await deleteStaleSummaries(admin, rfpId);
 
-    const { data: row, error: rfpErr } = await dataClient
-      .from("rfps")
-      .select("*")
-      .eq("id", rfpId)
-      .maybeSingle();
-
-    if (rfpErr || !row) {
+    try {
+      const { title, context } = await loadRfpContext(admin, rfpId);
+      rfpTitle = title ?? undefined;
+      rfpText = context;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "RFP not found.";
       return Response.json(
-        { error: rfpErr?.message ?? "RFP not found." },
-        { status: 404 },
+        { error: message },
+        { status: message === "RFP not found." ? 404 : 502 },
       );
     }
-
-    const { data: chunks, error: chunksErr } = await dataClient
-      .from("rfp_chunks")
-      .select("chunk_index, chunk_text, metadata")
-      .eq("rfp_id", rfpId)
-      .order("chunk_index", { ascending: true });
-
-    if (chunksErr) {
-      return Response.json({ error: chunksErr.message }, { status: 502 });
-    }
-
-    rfpTitle = row.title;
-    rfpText = buildRfpContext(row, chunks ?? []);
   }
 
   if (!rfpText?.trim()) {
@@ -339,69 +91,19 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const client = new OpenAI({ apiKey });
-  const model = "gpt-4.1-mini";
-
-  const userContent = [
-    rfpTitle ? `RFP Title: ${rfpTitle}` : null,
-    "Extract a bidder-facing structured summary. Include opportunity posture, contract details, technical work areas, submission guidance, critical deadlines, evaluation criteria, and points of contact when stated.",
-    "RFP database record, extracted attachment text, and indexed RFP text:",
-    '"""',
-    rfpText,
-    '"""',
-  ]
-    .filter((line): line is string => line !== null)
-    .join("\n");
-
   try {
-    const response = await client.responses.parse({
-      model,
-      input: [
-        { role: "system", content: SYSTEM_INSTRUCTIONS },
-        { role: "user", content: userContent },
-      ],
-      text: { format: zodTextFormat(RfpSummarySchema, "rfp_summary") },
-    });
-
-    if (!response.output_parsed) {
-      return Response.json(
-        {
-          error: "Model returned no parsed output.",
-          incomplete_details: response.incomplete_details ?? null,
-          status: response.status ?? null,
-        },
-        { status: 502 }
-      );
-    }
-
-    const summaryJson = JSON.stringify(response.output_parsed);
+    const summary = await generateSummary(apiKey, rfpTitle, rfpText);
 
     if (cacheTarget) {
-      const { error: upsertErr } = await cacheTarget.admin
-        .from("rfp_summaries")
-        .upsert(
-          {
-            rfp_id: cacheTarget.rfpId,
-            summary: summaryJson,
-            summary_type: GENERAL_SUMMARY_TYPE,
-            model,
-            prompt_version: DETAILED_SUMMARY_PROMPT_VERSION,
-            generated_at: new Date().toISOString(),
-          },
-          { onConflict: "rfp_id,summary_type,prompt_version" },
-        );
-
-      if (upsertErr) {
-        return Response.json(
-          {
-            error: `Summary generated but could not be saved: ${upsertErr.message}`,
-          },
-          { status: 502 },
-        );
+      try {
+        await storeSummary(cacheTarget.admin, cacheTarget.rfpId, summary);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Unknown error";
+        return Response.json({ error: message }, { status: 502 });
       }
     }
 
-    return Response.json(response.output_parsed);
+    return Response.json(summary);
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
     return Response.json({ error: message }, { status: 500 });

--- a/web/lib/server/summaryGenerate.ts
+++ b/web/lib/server/summaryGenerate.ts
@@ -1,0 +1,357 @@
+import OpenAI from "openai";
+import { zodTextFormat } from "openai/helpers/zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import type { Database, Json } from "@/lib/database.types";
+import {
+  DETAILED_SUMMARY_PROMPT_VERSION,
+  GENERAL_SUMMARY_TYPE,
+  RfpSummarySchema,
+  type RfpSummary,
+} from "@/lib/rfpSummary";
+
+export const SUMMARY_MODEL = "gpt-4.1-mini";
+
+export const SUMMARY_SYSTEM_INSTRUCTIONS = [
+  "You summarize US government RFPs (Requests for Proposal) for prospective contractors.",
+  "Only use facts that are explicitly present in the provided RFP database record, extracted attachment text, or indexed RFP chunks.",
+  "Do not speculate, infer, or pull information from outside the provided material.",
+  "If a field is not stated in the provided material, return 'unknown' for strings or an empty array for lists.",
+  "Canonical database fields are source material too; if a canonical line says 'Due date: ...' or 'Contact email: ...', you may cite that exact line.",
+  "Every deadline, evaluation criterion, contract detail, technical work area, submission instruction, contact, and opportunity-posture claim must include a verbatim citation quote copied from the provided material.",
+  "Actively look for opportunity posture signals: RFI, sources sought, market research, presolicitation, notice of intent, sole source, intended awardee, incumbent, follow-on, recompete, set-aside, and competition caveats.",
+  "Actively look for contract mechanics: solicitation number, notice type, NAICS, PSC, set-aside, contract type, pricing, period of performance, option periods, extension periods, place of performance, agency office, size standard, authority, and intended awardee.",
+  "Actively look for technical work areas: named systems, platforms, software/toolsets, maintenance/sustainment tasks, modernization/migration tasks, security requirements, clearances, support volumes, SLAs, ticketing tools, audit logging, role-based security, patching, upgrades, and deliverables.",
+  "Actively look for submission guidance: what vendors should submit, deadline, email/portal, page limits, format, whether submissions will only inform market research or a competition decision, and whether the government will pay for responses.",
+].join(" ");
+
+const MAX_CONTEXT_CHARS = 200_000;
+const MAX_SECTION_CHARS = 80_000;
+const PDF_URL_KEYS = [
+  "pdf_url_1",
+  "pdf_url_2",
+  "pdf_url_3",
+  "pdf_url_4",
+  "pdf_url_5",
+  "pdf_url_6",
+  "pdf_url_7",
+  "pdf_url_8",
+  "pdf_url_9",
+  "pdf_url_10",
+] as const;
+
+type AdminClient = SupabaseClient<Database>;
+type RfpRow = Database["public"]["Tables"]["rfps"]["Row"];
+type RfpChunkRow = Pick<
+  Database["public"]["Tables"]["rfp_chunks"]["Row"],
+  "chunk_index" | "chunk_text" | "metadata"
+>;
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function asArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function cleanString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function displayValue(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value.trim();
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => displayValue(item))
+      .filter(Boolean)
+      .join(", ");
+  }
+  const record = asRecord(value);
+  if (Object.keys(record).length === 0) return "";
+  return JSON.stringify(record);
+}
+
+function line(label: string, value: unknown): string | null {
+  const text = displayValue(value);
+  return text ? `${label}: ${text}` : null;
+}
+
+function pushSection(parts: string[], title: string, body: string): void {
+  const trimmed = body.trim();
+  if (!trimmed) return;
+  parts.push(`## ${title}\n${trimmed.slice(0, MAX_SECTION_CHARS)}`);
+}
+
+function compactJson(value: unknown): string {
+  if (value == null) return "";
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return "";
+  }
+}
+
+function withoutLargeTextFields(record: Record<string, unknown>) {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(record)) {
+    if (
+      key === "documents" ||
+      key === "extracted_document_text" ||
+      key === "extracted_document_texts"
+    ) {
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}
+
+function documentLines(metadata: Record<string, unknown>, row: RfpRow): string {
+  const lines: string[] = [];
+  const docs = asArray(metadata.documents);
+  docs.forEach((value, index) => {
+    const doc = asRecord(value);
+    const fields = [
+      line("label", doc.label),
+      line("type", doc.type),
+      line("description", doc.attachment_description),
+      line("source_url", doc.source_url),
+      line("drive_url", doc.url),
+      line("size_bytes", doc.size_bytes),
+    ].filter((item): item is string => Boolean(item));
+    if (fields.length) {
+      lines.push(`Document ${index + 1}: ${fields.join("; ")}`);
+    }
+  });
+
+  PDF_URL_KEYS.forEach((key) => {
+    const url = row[key];
+    if (typeof url === "string" && url.trim()) {
+      lines.push(`${key}: ${url.trim()}`);
+    }
+  });
+
+  return Array.from(new Set(lines)).join("\n");
+}
+
+function extractedDocumentText(metadata: Record<string, unknown>): string {
+  const blocks: string[] = [];
+  for (const value of asArray(metadata.extracted_document_texts)) {
+    const entry = asRecord(value);
+    const text = cleanString(entry.text);
+    if (!text) continue;
+    const label = cleanString(entry.label) || "Attached document";
+    const type = cleanString(entry.type);
+    blocks.push(
+      [`### ${label}${type ? ` (${type})` : ""}`, text].join("\n"),
+    );
+  }
+
+  const singleText = cleanString(metadata.extracted_document_text);
+  if (singleText && !blocks.some((block) => block.includes(singleText.slice(0, 100)))) {
+    blocks.push(`### Extracted attachment text\n${singleText}`);
+  }
+
+  return blocks.join("\n\n---\n\n");
+}
+
+export function buildRfpContext(row: RfpRow, chunks: RfpChunkRow[]): string {
+  const metadata = asRecord(row.metadata as Json | null);
+  const rawData = asRecord(row.raw_data as Json | null);
+  const rawMetadata = asRecord(rawData.metadata);
+  const combinedMetadata = { ...rawMetadata, ...metadata };
+  const parts: string[] = [];
+
+  pushSection(
+    parts,
+    "Canonical RFP Fields",
+    [
+      line("Source", row.source),
+      line("External ID", row.external_id),
+      line("Title", row.title),
+      line("Short name", row.name),
+      line("Department / agency", row.department),
+      line("Status", row.status),
+      line("Posted date", row.posted_date),
+      line("Due date", row.due_date),
+      line("Location", row.location),
+      line("State", row.state),
+      line("Location level", row.location_level),
+      line("Contract amount minimum", row.contract_amount_min),
+      line("Contract amount maximum", row.contract_amount_max),
+      line("Tags", row.tags),
+      line("Contact name", row.contact_name),
+      line("Contact email", row.contact_email),
+      line("Contact phone", row.contact_phone),
+    ]
+      .filter((item): item is string => Boolean(item))
+      .join("\n"),
+  );
+
+  pushSection(parts, "Description", row.description ?? "");
+  pushSection(parts, "Statement of Work", row.statement_of_work ?? "");
+  pushSection(parts, "Deliverables", (row.deliverables ?? []).join("\n"));
+  pushSection(parts, "Attached Documents", documentLines(combinedMetadata, row));
+  pushSection(
+    parts,
+    "Source Metadata",
+    compactJson(withoutLargeTextFields(combinedMetadata)),
+  );
+  pushSection(
+    parts,
+    "Extracted Attachment Text",
+    extractedDocumentText(combinedMetadata),
+  );
+
+  if (chunks.length > 0) {
+    pushSection(
+      parts,
+      "Indexed RFP Chunks",
+      chunks
+        .sort((a, b) => a.chunk_index - b.chunk_index)
+        .map((chunk) => {
+          const meta = compactJson(chunk.metadata);
+          return [
+            `### Chunk ${chunk.chunk_index}`,
+            meta ? `Metadata: ${meta}` : "",
+            chunk.chunk_text,
+          ]
+            .filter(Boolean)
+            .join("\n");
+        })
+        .join("\n\n---\n\n"),
+    );
+  }
+
+  return parts.join("\n\n").slice(0, MAX_CONTEXT_CHARS);
+}
+
+export async function loadRfpContext(
+  admin: AdminClient,
+  rfpId: string,
+): Promise<{ title: string | null; context: string }> {
+  const { data: row, error: rfpErr } = await admin
+    .from("rfps")
+    .select("*")
+    .eq("id", rfpId)
+    .maybeSingle();
+
+  if (rfpErr || !row) {
+    throw new Error(rfpErr?.message ?? "RFP not found.");
+  }
+
+  const { data: chunks, error: chunksErr } = await admin
+    .from("rfp_chunks")
+    .select("chunk_index, chunk_text, metadata")
+    .eq("rfp_id", rfpId)
+    .order("chunk_index", { ascending: true });
+
+  if (chunksErr) {
+    throw new Error(chunksErr.message);
+  }
+
+  return { title: row.title, context: buildRfpContext(row, chunks ?? []) };
+}
+
+export async function generateSummary(
+  openaiApiKey: string,
+  rfpTitle: string | null | undefined,
+  rfpText: string,
+): Promise<RfpSummary> {
+  const client = new OpenAI({ apiKey: openaiApiKey });
+
+  const userContent = [
+    rfpTitle ? `RFP Title: ${rfpTitle}` : null,
+    "Extract a bidder-facing structured summary. Include opportunity posture, contract details, technical work areas, submission guidance, critical deadlines, evaluation criteria, and points of contact when stated.",
+    "RFP database record, extracted attachment text, and indexed RFP text:",
+    '"""',
+    rfpText,
+    '"""',
+  ]
+    .filter((line): line is string => line !== null)
+    .join("\n");
+
+  const response = await client.responses.parse({
+    model: SUMMARY_MODEL,
+    input: [
+      { role: "system", content: SUMMARY_SYSTEM_INSTRUCTIONS },
+      { role: "user", content: userContent },
+    ],
+    text: { format: zodTextFormat(RfpSummarySchema, "rfp_summary") },
+  });
+
+  if (!response.output_parsed) {
+    throw new Error(
+      `Model returned no parsed output (status: ${response.status ?? "unknown"}).`,
+    );
+  }
+
+  return response.output_parsed;
+}
+
+/** Delete stale summary rows (old prompt versions) for this RFP. */
+export async function deleteStaleSummaries(
+  admin: AdminClient,
+  rfpId: string,
+): Promise<void> {
+  await admin
+    .from("rfp_summaries")
+    .delete()
+    .eq("rfp_id", rfpId)
+    .eq("summary_type", GENERAL_SUMMARY_TYPE)
+    .is("prompt_version", null);
+  await admin
+    .from("rfp_summaries")
+    .delete()
+    .eq("rfp_id", rfpId)
+    .eq("summary_type", GENERAL_SUMMARY_TYPE)
+    .neq("prompt_version", DETAILED_SUMMARY_PROMPT_VERSION);
+}
+
+export async function storeSummary(
+  admin: AdminClient,
+  rfpId: string,
+  summary: RfpSummary,
+): Promise<void> {
+  const { error } = await admin.from("rfp_summaries").upsert(
+    {
+      rfp_id: rfpId,
+      summary: JSON.stringify(summary),
+      summary_type: GENERAL_SUMMARY_TYPE,
+      model: SUMMARY_MODEL,
+      prompt_version: DETAILED_SUMMARY_PROMPT_VERSION,
+      generated_at: new Date().toISOString(),
+    },
+    { onConflict: "rfp_id,summary_type,prompt_version" },
+  );
+
+  if (error) {
+    throw new Error(`Summary generated but could not be saved: ${error.message}`);
+  }
+}
+
+/**
+ * Full pipeline for one RFP: build context from the DB row + chunks, run the
+ * LLM, and upsert the result into `rfp_summaries`.
+ */
+export async function generateAndStoreSummary(
+  admin: AdminClient,
+  openaiApiKey: string,
+  rfpId: string,
+): Promise<RfpSummary> {
+  await deleteStaleSummaries(admin, rfpId);
+  const { title, context } = await loadRfpContext(admin, rfpId);
+  if (!context.trim()) {
+    throw new Error("No RFP text was available for summary generation.");
+  }
+  const summary = await generateSummary(openaiApiKey, title, context);
+  await storeSummary(admin, rfpId, summary);
+  return summary;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "backfill:summaries": "tsx scripts/backfillSummaries.ts"
   },
   "dependencies": {
     "@ai-sdk/groq": "^3.0.39",
@@ -30,9 +31,12 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "tsx": "^4.22.4",
+    "typescript": "^5",
+    "ws": "^8.21.0"
   }
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       openai:
         specifier: ^6.38.0
-        version: 6.38.0(zod@4.4.3)
+        version: 6.38.0(ws@8.21.0)(zod@4.4.3)
       pdfjs-dist:
         specifier: ^5.4.624
         version: 5.7.284
@@ -66,6 +66,9 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.2.3(@types/react@19.2.14)
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.7.0)
@@ -75,9 +78,15 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.3.0
+      tsx:
+        specifier: ^4.22.4
+        version: 4.22.4
       typescript:
         specifier: ^5
         version: 5.9.3
+      ws:
+        specifier: ^8.21.0
+        version: 8.21.0
 
 packages:
 
@@ -188,6 +197,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -836,6 +1001,9 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.59.3':
     resolution: {integrity: sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1299,6 +1467,11 @@ packages:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
 
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1487,6 +1660,11 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -2440,6 +2618,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2548,6 +2731,18 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -2716,6 +2911,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
@@ -3269,6 +3542,10 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.41
+
   '@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3804,6 +4081,35 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -4066,6 +4372,9 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -4796,8 +5105,9 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
-  openai@6.38.0(zod@4.4.3):
+  openai@6.38.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
+      ws: 8.21.0
       zod: 4.4.3
 
   optionator@0.9.4:
@@ -5259,6 +5569,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -5449,6 +5765,8 @@ snapshots:
       isexe: 2.0.0
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.0: {}
 
   yallist@3.1.1: {}
 

--- a/web/scripts/backfillSummaries.ts
+++ b/web/scripts/backfillSummaries.ts
@@ -1,0 +1,122 @@
+/**
+ * Backfill LLM summaries for all dashboard-visible RFPs so users hit the
+ * cached path instantly instead of waiting on generation.
+ *
+ * Usage (from web/):
+ *   pnpm backfill:summaries            # only RFPs missing a current summary
+ *   pnpm backfill:summaries -- --force # regenerate all
+ *   pnpm backfill:summaries -- --limit=10
+ */
+import path from "node:path";
+import { WebSocket } from "ws";
+
+const CONCURRENCY = 3;
+
+// supabase-js requires a WebSocket implementation on Node < 22.
+if (!globalThis.WebSocket) {
+  (globalThis as Record<string, unknown>).WebSocket = WebSocket;
+}
+
+try {
+  process.loadEnvFile(path.join(__dirname, "..", ".env"));
+} catch {
+  // .env may be absent in CI; rely on the ambient environment.
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const force = args.includes("--force");
+  const limitArg = args.find((a) => a.startsWith("--limit="));
+  const limit = limitArg ? Number(limitArg.split("=")[1]) : Infinity;
+  return { force, limit };
+}
+
+async function main() {
+  const { force, limit } = parseArgs();
+
+  // Imported lazily so the WebSocket polyfill and env vars are in place
+  // before supabase-js and the admin client module are evaluated.
+  const { DETAILED_SUMMARY_PROMPT_VERSION, GENERAL_SUMMARY_TYPE } =
+    await import("@/lib/rfpSummary");
+  const { generateAndStoreSummary } = await import(
+    "@/lib/server/summaryGenerate"
+  );
+  const { createServiceRoleClient } = await import("@/lib/supabase/admin");
+
+  const openaiApiKey = process.env.OPENAI_API_KEY;
+  if (!openaiApiKey) {
+    throw new Error("OPENAI_API_KEY is not set.");
+  }
+  const admin = createServiceRoleClient();
+
+  const { data: rfps, error: rfpErr } = await admin
+    .from("rfps")
+    .select("id, title")
+    .eq("status", "active")
+    .eq("is_relevant", true)
+    .order("due_date", { ascending: true, nullsFirst: false });
+  if (rfpErr) throw new Error(`Failed to load RFPs: ${rfpErr.message}`);
+
+  const allIds = (rfps ?? []).map((r) => r.id);
+  console.log(`Found ${allIds.length} active, relevant RFPs.`);
+
+  let targetIds = allIds;
+  if (!force && allIds.length > 0) {
+    const { data: existing, error: sumErr } = await admin
+      .from("rfp_summaries")
+      .select("rfp_id")
+      .in("rfp_id", allIds)
+      .eq("summary_type", GENERAL_SUMMARY_TYPE)
+      .eq("prompt_version", DETAILED_SUMMARY_PROMPT_VERSION);
+    if (sumErr) {
+      throw new Error(`Failed to load existing summaries: ${sumErr.message}`);
+    }
+    const done = new Set((existing ?? []).map((row) => row.rfp_id));
+    targetIds = allIds.filter((id) => !done.has(id));
+    console.log(
+      `${done.size} already have a current summary; ${targetIds.length} to generate.`,
+    );
+  }
+
+  targetIds = targetIds.slice(0, limit);
+  if (targetIds.length === 0) {
+    console.log("Nothing to do.");
+    return;
+  }
+
+  const titleById = new Map((rfps ?? []).map((r) => [r.id, r.title ?? r.id]));
+  let completed = 0;
+  let failed = 0;
+  const queue = [...targetIds];
+
+  async function worker() {
+    for (let rfpId = queue.shift(); rfpId; rfpId = queue.shift()) {
+      const label = titleById.get(rfpId) ?? rfpId;
+      try {
+        await generateAndStoreSummary(admin, openaiApiKey!, rfpId);
+        completed += 1;
+        console.log(
+          `[${completed + failed}/${targetIds.length}] ok      ${label}`,
+        );
+      } catch (err) {
+        failed += 1;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(
+          `[${completed + failed}/${targetIds.length}] FAILED  ${label}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(CONCURRENCY, targetIds.length) }, worker),
+  );
+
+  console.log(`\nDone. ${completed} generated, ${failed} failed.`);
+  if (failed > 0) process.exitCode = 1;
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Previously, summaries were only generated on-demand when a user clicked
"Generate summary", so every first view of an RFP waited ~15s on an LLM call.
This PR adds a batch backfill script that pre-generates summaries for all
dashboard-visible RFPs and stores them in `rfp_summaries.`

## Changes

- **`web/lib/server/summaryGenerate.ts` (new):** extracted the summary pipeline
  out of the API route into reusable functions — `buildRfpContext()`,
  `loadRfpContext()`, `generateSummary()`, `storeSummary()`, and a one-call
  `generateAndStoreSummary()`.
- **`web/app/api/summary/route.ts`:** refactored to use the shared module.
  Behavior unchanged (auth check, stale-version cleanup, upsert) — just thinner.
- **`web/scripts/backfillSummaries.ts` (new):** backfill script that
  - queries the same RFPs the dashboard shows (`status = 'active'`, `is_relevant = true`)
  - skips RFPs that already have a summary at the current prompt version (`detailed-v4`)
  - generates with 3 concurrent workers using the service-role client and
    upserts into `rfp_summaries`